### PR TITLE
Fix for view/edit task on Laravel5.5

### DIFF
--- a/src/Http/Controllers/TasksController.php
+++ b/src/Http/Controllers/TasksController.php
@@ -80,7 +80,7 @@ class TasksController extends Controller
     public function view($task)
     {
         return view('totem::tasks.view', [
-            'task'  => $task,
+            'task'  => $this->tasks->find($task),
         ]);
     }
 
@@ -93,7 +93,7 @@ class TasksController extends Controller
     public function edit($task)
     {
         return view('totem::tasks.form', [
-            'task'          => $task,
+            'task'          => $this->tasks->find($task),
             'commands'      => collect(Artisan::all())->sortBy(function ($command) {
                 return $command->getDescription();
             }),


### PR DESCRIPTION
the id of the task is passed to the view, not the task itself.

Error was:
Trying to get property of non-object

vendor/studio/laravel-totem/resources/views/tasks/view.blade.php