### PR TITLE
fix missing prefix variable

### DIFF
--- a/src/Providers/TotemServiceProvider.php
+++ b/src/Providers/TotemServiceProvider.php
@@ -51,7 +51,7 @@ class TotemServiceProvider extends ServiceProvider
         $this->app->register(TotemEventServiceProvider::class);
 
         try {
-            if (Schema::hasTable('tasks')) {
+            if (Schema::hasTable(config('totem.table_prefix').'tasks')) {
                 $this->app->register(ConsoleServiceProvider::class);
             }
         } catch (\PDOException $ex) {


### PR DESCRIPTION
Hi,
I found that my tasks wasn't trigger while I set the environment variable `TOTEM_TABLE_PREFIX`
following the code, then I found that here might be missing variable from config.
please check  :)