### PR TITLE
[L5.4] added table prefix to the migrations and config (empty for BC)

### DIFF
--- a/config/totem.php
+++ b/config/totem.php
@@ -1,6 +1,8 @@
 <?php
 
 return [
+    'table_prefix' => '',
+
     'frequencies'  => [
         [
             'label'             => 'Every Minute',

--- a/database/migrations/2017_08_05_194349_create_tasks_table.php
+++ b/database/migrations/2017_08_05_194349_create_tasks_table.php
@@ -13,7 +13,7 @@ class CreateTasksTable extends Migration
      */
     public function up()
     {
-        Schema::create('tasks', function (Blueprint $table) {
+        Schema::create(config('totem.table_prefix').'tasks', function (Blueprint $table) {
             $table->increments('id');
             $table->string('description');
             $table->string('command');
@@ -35,6 +35,6 @@ class CreateTasksTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('tasks');
+        Schema::dropIfExists(config('totem.table_prefix').'tasks');
     }
 }

--- a/database/migrations/2017_08_05_195539_create_task_frequencies_table.php
+++ b/database/migrations/2017_08_05_195539_create_task_frequencies_table.php
@@ -13,7 +13,7 @@ class CreateTaskFrequenciesTable extends Migration
      */
     public function up()
     {
-        Schema::create('task_frequencies', function (Blueprint $table) {
+        Schema::create(config('totem.table_prefix').'task_frequencies', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('task_id');
             $table->string('label');
@@ -29,6 +29,6 @@ class CreateTaskFrequenciesTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('task_frequencies');
+        Schema::dropIfExists(config('totem.table_prefix').'task_frequencies');
     }
 }

--- a/database/migrations/2017_08_05_201914_create_task_results_table.php
+++ b/database/migrations/2017_08_05_201914_create_task_results_table.php
@@ -13,7 +13,7 @@ class CreateTaskResultsTable extends Migration
      */
     public function up()
     {
-        Schema::create('task_results', function (Blueprint $table) {
+        Schema::create(config('totem.table_prefix').'task_results', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('task_id');
             $table->timestamp('ran_at')->useCurrent();
@@ -30,6 +30,6 @@ class CreateTaskResultsTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('task_results');
+        Schema::dropIfExists(config('totem.table_prefix').'task_results');
     }
 }

--- a/database/migrations/2017_08_24_085132_create_frequency_parameters_table.php
+++ b/database/migrations/2017_08_24_085132_create_frequency_parameters_table.php
@@ -13,7 +13,7 @@ class CreateFrequencyParametersTable extends Migration
      */
     public function up()
     {
-        Schema::create('frequency_parameters', function (Blueprint $table) {
+        Schema::create(config('totem.table_prefix').'frequency_parameters', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('frequency_id');
             $table->string('name');
@@ -29,6 +29,6 @@ class CreateFrequencyParametersTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('frequency_parameters');
+        Schema::dropIfExists(config('totem.table_prefix').'frequency_parameters');
     }
 }

--- a/database/migrations/2017_08_26_083622_alter_tasks_table_add_notifications_fields.php
+++ b/database/migrations/2017_08_26_083622_alter_tasks_table_add_notifications_fields.php
@@ -13,7 +13,7 @@ class AlterTasksTableAddNotificationsFields extends Migration
      */
     public function up()
     {
-        Schema::table('tasks', function (Blueprint $table) {
+        Schema::table(config('totem.table_prefix').'tasks', function (Blueprint $table) {
             $table->string('notification_phone_number')->nullable()->after('notification_email_address');
             $table->string('notification_slack_webhook')->nullable()->after('notification_phone_number');
         });
@@ -26,7 +26,7 @@ class AlterTasksTableAddNotificationsFields extends Migration
      */
     public function down()
     {
-        Schema::table('tasks', function (Blueprint $table) {
+        Schema::table(config('totem.table_prefix').'tasks', function (Blueprint $table) {
             $table->dropColumn('notification_phone_number');
             $table->dropColumn('notification_slack_webhook');
         });

--- a/src/Frequency.php
+++ b/src/Frequency.php
@@ -4,10 +4,11 @@ namespace Studio\Totem;
 
 use Studio\Totem\Traits\HasParameters;
 use Illuminate\Database\Eloquent\Model;
+use Studio\Totem\Traits\HasTablePrefix;
 
 class Frequency extends Model
 {
-    use HasParameters;
+    use HasParameters, HasTablePrefix;
 
     protected $table = 'task_frequencies';
 

--- a/src/Parameter.php
+++ b/src/Parameter.php
@@ -3,9 +3,12 @@
 namespace Studio\Totem;
 
 use Illuminate\Database\Eloquent\Model;
+use Studio\Totem\Traits\HasTablePrefix;
 
 class Parameter extends Model
 {
+    use HasTablePrefix;
+
     protected $table = 'frequency_parameters';
 
     protected $fillable = [

--- a/src/Result.php
+++ b/src/Result.php
@@ -3,9 +3,12 @@
 namespace Studio\Totem;
 
 use Illuminate\Database\Eloquent\Model;
+use Studio\Totem\Traits\HasTablePrefix;
 
 class Result extends Model
 {
+    use HasTablePrefix;
+
     protected $table = 'task_results';
 
     protected $fillable = [

--- a/src/Task.php
+++ b/src/Task.php
@@ -5,11 +5,12 @@ namespace Studio\Totem;
 use Cron\CronExpression;
 use Illuminate\Database\Eloquent\Model;
 use Studio\Totem\Traits\HasFrequencies;
+use Studio\Totem\Traits\HasTablePrefix;
 use Illuminate\Notifications\Notifiable;
 
 class Task extends Model
 {
-    use Notifiable, HasFrequencies;
+    use Notifiable, HasFrequencies, HasTablePrefix;
 
     /**
      * The attributes that are mass assignable.

--- a/src/Traits/HasTablePrefix.php
+++ b/src/Traits/HasTablePrefix.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Studio\Totem\Traits;
+
+trait HasTablePrefix
+{
+    /**
+     * Get the table associated with the model.
+     *
+     * @return string
+     */
+    public function getTable()
+    {
+        return config('totem.table_prefix').parent::getTable();
+    }
+}

--- a/tests/Unit/ModelsTest.php
+++ b/tests/Unit/ModelsTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Studio\Totem\Tests\Unit;
+
+use Studio\Totem\Task;
+use Studio\Totem\Result;
+use Studio\Totem\Frequency;
+use Studio\Totem\Parameter;
+use Studio\Totem\Tests\TestCase;
+
+class ModelsTest extends TestCase
+{
+    /** @test */
+    public function it_uses_table_prefix_from_the_config()
+    {
+        config(['totem.table_prefix' => 'prefixed_']);
+
+        $this->assertEquals('prefixed_tasks', (new Task)->getTable());
+        $this->assertEquals('prefixed_task_results', (new Result)->getTable());
+        $this->assertEquals('prefixed_task_frequencies', (new Frequency)->getTable());
+        $this->assertEquals('prefixed_frequency_parameters', (new Parameter)->getTable());
+    }
+}


### PR DESCRIPTION
Added config entry for db tables prefix (using config rather than `env` directly is preferable way - unlike in v2).
Left config entry as empty string for BC.

cheers!