### PR TITLE
Parse quoted parameters

### DIFF
--- a/src/Task.php
+++ b/src/Task.php
@@ -86,7 +86,7 @@ class Task extends TotemModel
                             [$param[0] => $value] :
                             [$argument_index++ => $value];
                     }
-                    
+
                     return [$param[0] => $value];
                 }
 

--- a/src/Task.php
+++ b/src/Task.php
@@ -86,6 +86,7 @@ class Task extends TotemModel
                             [$param[0] => $value] :
                             [$argument_index++ => $value];
                     }
+                    
                     return [$param[0] => $value];
                 }
 

--- a/src/Task.php
+++ b/src/Task.php
@@ -79,9 +79,19 @@ class Task extends TotemModel
             $parameters = collect($matches)->mapWithKeys(function ($parameter) use ($console, &$argument_index) {
                 $param = explode('=', $parameter[0]);
 
-                return count($param) > 1
-                    ? ($console ? (starts_with($param[0], '--') ? [$param[0] => $param[1]] : [$argument_index++ => $param[1]]) : [$param[0] => $param[1]])
-                    : (starts_with($param[0], '--') && ! $console ? [$param[0] => true] : [$argument_index++ => $param[0]]);
+                if(count($param) > 1) {
+                    $value = trim(trim($param[1], '"'), "'");
+                    if($console) {
+                        return starts_with($param[0], '--') ?
+                            [$param[0] => $value] :
+                            [$argument_index++ => $value];
+                    }
+                    return [$param[0] => $value];
+                }
+
+                return starts_with($param[0], '--') && ! $console ?
+                    [$param[0] => true] :
+                    [$argument_index++ => $param[0]];
             })->toArray();
 
             return $parameters;

--- a/src/Task.php
+++ b/src/Task.php
@@ -80,14 +80,14 @@ class Task extends TotemModel
                 $param = explode('=', $parameter[0]);
 
                 if (count($param) > 1) {
-                    $value = trim(trim($param[1], '"'), "'");
+                    $trimmed_param = trim(trim($param[1], '"'), "'");
                     if ($console) {
                         return starts_with($param[0], '--') ?
-                            [$param[0] => $value] :
-                            [$argument_index++ => $value];
+                            [$param[0] => $trimmed_param] :
+                            [$argument_index++ => $trimmed_param];
                     }
 
-                    return [$param[0] => $value];
+                    return [$param[0] => $trimmed_param];
                 }
 
                 return starts_with($param[0], '--') && ! $console ?

--- a/src/Task.php
+++ b/src/Task.php
@@ -79,9 +79,9 @@ class Task extends TotemModel
             $parameters = collect($matches)->mapWithKeys(function ($parameter) use ($console, &$argument_index) {
                 $param = explode('=', $parameter[0]);
 
-                if(count($param) > 1) {
+                if (count($param) > 1) {
                     $value = trim(trim($param[1], '"'), "'");
-                    if($console) {
+                    if ($console) {
                         return starts_with($param[0], '--') ?
                             [$param[0] => $value] :
                             [$argument_index++ => $value];


### PR DESCRIPTION
Given parameters: --url='https://noort.be' --header='Authorization: Basic XXX' resulted in the values (for url and header) that were quoted. The PR proposed solves this by trimming the value for single and double quotes.