### PR TITLE
clarified maintenance mode info display

### DIFF
--- a/resources/views/tasks/view.blade.php
+++ b/resources/views/tasks/view.blade.php
@@ -68,8 +68,12 @@
         @endif
         @if($task->run_in_maintenance)
             <li>
-                <span class="uk-float-left">Runs in maintenance mode</span>
+                <span class="uk-float-left">Task <b>WILL</b> still run when in maintenance mode</span>
             </li>
+        @else
+            <li>
+                <span class="uk-float-left">Task will <b>NOT</b> run when in maintenance mode</span>
+            </li>        
         @endif
     </ul>
 @stop


### PR DESCRIPTION
The current verbiage makes it seem that the task will ONLY run in maintenance mode, which is not correct. 
This makes it perfectly clear what the task will do in maintenance mode