### PR TITLE
fix #122: don't concatenate table prefixs recursively

### DIFF
--- a/src/TotemModel.php
+++ b/src/TotemModel.php
@@ -11,10 +11,10 @@ class TotemModel extends Model
      */
     public function getTable()
     {
-        if(str_contains(parent::getTable(), config('totem.table_prefix'))) {
+        if (str_contains(parent::getTable(), config('totem.table_prefix'))) {
             return parent::getTable();
         }
-        
+
         return config('totem.table_prefix').parent::getTable();
     }
 }

--- a/src/TotemModel.php
+++ b/src/TotemModel.php
@@ -11,6 +11,10 @@ class TotemModel extends Model
      */
     public function getTable()
     {
+        if(str_contains(parent::getTable(), config('totem.table_prefix'))) {
+            return parent::getTable();
+        }
+        
         return config('totem.table_prefix').parent::getTable();
     }
 }


### PR DESCRIPTION
### Issue

(https://github.com/codestudiohq/laravel-totem/issues/122)

After Laravel 5.7.12 version (this PR https://github.com/laravel/framework/pull/26085/files#diff-d8e24a5815a26f7211e66db787be647fR398), when the model is rehydrated (calling newInstance function on Model), `getTable` is calling when the model has already name, and if this name contains totem prefix, its concatenated again.

Steps to reproduce:

- Create new installation (or update an existing one) of Laravel >= 5.7.12
- Install Laravel Totem 4.0.0
- Set the totem prefix with `TOTEM_TABLE_PREFIX` var filled at .env file
- Migrate database
- On Totem dashboard, try to create new task, when it ends, an exception will be thrown with non existing table (malformed name)

### Fix

Simply when `getTable` is calling checks if is table name already contains the prefix. If you don't use prefix this will not set.