### PR TITLE
Fixed typo that is causing fatal error in PHP 7.3

### DIFF
--- a/src/Providers/TotemServiceProvider.php
+++ b/src/Providers/TotemServiceProvider.php
@@ -64,7 +64,7 @@ class TotemServiceProvider extends ServiceProvider
         }
 
         if (! defined('TOTEM_DATABASE_CONNECTION')) {
-            define('TOTEM_DATABASE_CONNECTION', config('totem.database_connection'), Schema::getConnection()->getName());
+            define('TOTEM_DATABASE_CONNECTION', config('totem.database_connection', Schema::getConnection()->getName()));
         }
 
         $this->commands([


### PR DESCRIPTION
The affected line was meant to fallback to the default db connection if the user does not specify one in his .env file

But instead the default connection name was being passed to define() third parameter which is meant to set whether the constant should be case sensitive or not.

PHP 7.3 added a deprecation "Declaration of case-insensitive constants is deprecated" which causes an error