### PR TITLE
Fixes #132 - Implement ShouldBroadcastNow to use sync driver

### DIFF
--- a/src/Events/BroadcastingEvent.php
+++ b/src/Events/BroadcastingEvent.php
@@ -5,9 +5,9 @@ namespace Studio\Totem\Events;
 use Studio\Totem\Task;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 
-class BroadcastingEvent extends TaskEvent implements ShouldBroadcast
+class BroadcastingEvent extends TaskEvent implements ShouldBroadcastNow
 {
     use InteractsWithSockets;
 


### PR DESCRIPTION
Currently the broadcast events are being sent to the queue when they should be immediately executed and also not be dependent on the queue. Implementing ShouldBroadcastNow instead of ShouldBroadcast will use the sync driver instead of the defined queue driver. This also fixes a possible issue when using the database driver for queue, which should reduce or eliminate deadlocks in the jobs table depending on the number of running events/crons.