### PR TITLE
Support SSL/TLS Termination

### DIFF
--- a/resources/views/tasks/form.blade.php
+++ b/resources/views/tasks/form.blade.php
@@ -4,7 +4,7 @@
     - {{ $task->exists ? 'Update' : 'Create'}} Task
 @stop
 @section('main-panel-before')
-    <form action="{{ request()->fullUrl() }}" method="POST">
+    <form method="POST">
         {{csrf_field()}}
 @stop
 @section('title')


### PR DESCRIPTION
https://github.com/codestudiohq/laravel-totem/issues/179

The html form attribute is not required, and in environments that use SSL/TLS Termination this URL is incorrect and causes the form not to submit properly.