### PR TITLE
Toggle broadcasting

### DIFF
--- a/config/totem.php
+++ b/config/totem.php
@@ -228,4 +228,9 @@ return [
         'whitelist' => true,
     ],
     'database_connection' => env('TOTEM_DATABASE_CONNECTION'),
+
+    'broadcasting' => [
+        'enabled' => env('TOTEM_BROADCASTING_ENABLED', true),
+        'queue' => env('TOTEM_BROADCASTING_QUEUE', 'task.events'),
+    ],
 ];

--- a/config/totem.php
+++ b/config/totem.php
@@ -231,6 +231,6 @@ return [
 
     'broadcasting' => [
         'enabled' => env('TOTEM_BROADCASTING_ENABLED', true),
-        'queue' => env('TOTEM_BROADCASTING_QUEUE', 'task.events'),
+        'channel' => env('TOTEM_BROADCASTING_CHANNEL', 'task.events'),
     ],
 ];

--- a/src/Events/BroadcastingEvent.php
+++ b/src/Events/BroadcastingEvent.php
@@ -2,7 +2,6 @@
 
 namespace Studio\Totem\Events;
 
-use Studio\Totem\Task;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
@@ -12,27 +11,22 @@ class BroadcastingEvent extends TaskEvent implements ShouldBroadcast
     use InteractsWithSockets;
 
     /**
-     * @var Task
-     */
-    public $task;
-
-    /**
-     * constructor.
-     *
-     * @param Task $task
-     */
-    public function __construct(Task $task)
-    {
-        parent::__construct($task);
-    }
-
-    /**
      * Get the channels the event should broadcast on.
      *
      * @return \Illuminate\Broadcasting\Channel|\Illuminate\Broadcasting\Channel[]|PrivateChannel
      */
     public function broadcastOn()
     {
-        return new PrivateChannel('task.events');
+        return new PrivateChannel(config('totem.broadcasting.queue'));
+    }
+
+    /**
+     * Toggles event broadcasting on/off based on config value.
+     *
+     * @return bool
+     */
+    public function broadcastWhen()
+    {
+        return config('totem.broadcasting.enabled');
     }
 }

--- a/src/Events/BroadcastingEvent.php
+++ b/src/Events/BroadcastingEvent.php
@@ -17,7 +17,7 @@ class BroadcastingEvent extends TaskEvent implements ShouldBroadcast
      */
     public function broadcastOn()
     {
-        return new PrivateChannel(config('totem.broadcasting.queue'));
+        return new PrivateChannel(config('totem.broadcasting.channel'));
     }
 
     /**


### PR DESCRIPTION
This PR adds the ability to toggle broadcasting on/off as well as allows setting the specific channel name it should broadcast on.

New environment variables are `TOTEM_BROADCASTING_ENABLED` (defaults to true) and `TOTEM_BROADCASTING_CHANNEL` (defaults to `task.events`)

Relates to #132
Relates to #141

