### PR TITLE
Single and double dashes should be treated the same

### DIFF
--- a/src/Task.php
+++ b/src/Task.php
@@ -81,26 +81,44 @@ class Task extends TotemModel
             preg_match_all($regex, $this->parameters, $matches, PREG_SET_ORDER, 0);
 
             $argument_index = 0;
-            $parameters = collect($matches)->mapWithKeys(function ($parameter) use ($console, &$argument_index) {
+
+            $duplicate_parameter_index = function (array $carry, array $param, string $trimmed_param) {
+                if (! isset($carry[$param[0]])) {
+                    $carry[$param[0]] = $trimmed_param;
+                } else {
+                    if (! is_array($carry[$param[0]])) {
+                        $carry[$param[0]] = [$carry[$param[0]]];
+                    }
+                    $carry[$param[0]][] = $trimmed_param;
+                }
+
+                return $carry;
+            };
+
+            return collect($matches)->reduce(function ($carry, $parameter) use ($console, &$argument_index, $duplicate_parameter_index) {
                 $param = explode('=', $parameter[0]);
 
                 if (count($param) > 1) {
                     $trimmed_param = trim(trim($param[1], '"'), "'");
                     if ($console) {
-                        return starts_with($param[0], ['--', '-']) ?
-                            [$param[0] => $trimmed_param] :
-                            [$argument_index++ => $trimmed_param];
+                        if (starts_with($param[0], ['--', '-'])) {
+                            $carry = $duplicate_parameter_index($carry, $param, $trimmed_param);
+                        } else {
+                            $carry[$argument_index++] = $trimmed_param;
+                        }
+
+                        return $carry;
                     }
 
-                    return [$param[0] => $trimmed_param];
+                    return $duplicate_parameter_index($carry, $param, $trimmed_param);
                 }
 
-                return starts_with($param[0], ['--', '-']) && ! $console ?
-                    [$param[0] => true] :
-                    [$argument_index++ => $param[0]];
-            })->toArray();
+                starts_with($param[0], ['--', '-']) && ! $console ?
+                    $carry[$param[0]] = true :
+                    $carry[$argument_index++] = $param[0];
 
-            return $parameters;
+                return $carry;
+            }, []);
         }
 
         return [];

--- a/src/Task.php
+++ b/src/Task.php
@@ -95,7 +95,7 @@ class Task extends TotemModel
                     return [$param[0] => $trimmed_param];
                 }
 
-                return starts_with($param[0],  ['--', '-']) && ! $console ?
+                return starts_with($param[0], ['--', '-']) && ! $console ?
                     [$param[0] => true] :
                     [$argument_index++ => $param[0]];
             })->toArray();

--- a/src/Task.php
+++ b/src/Task.php
@@ -87,7 +87,7 @@ class Task extends TotemModel
                 if (count($param) > 1) {
                     $trimmed_param = trim(trim($param[1], '"'), "'");
                     if ($console) {
-                        return starts_with($param[0], '--') ?
+                        return starts_with($param[0], ['--', '-']) ?
                             [$param[0] => $trimmed_param] :
                             [$argument_index++ => $trimmed_param];
                     }
@@ -95,7 +95,7 @@ class Task extends TotemModel
                     return [$param[0] => $trimmed_param];
                 }
 
-                return starts_with($param[0], '--') && ! $console ?
+                return starts_with($param[0],  ['--', '-']) && ! $console ?
                     [$param[0] => true] :
                     [$argument_index++ => $param[0]];
             })->toArray();

--- a/tests/Feature/CompileParametersTest.php
+++ b/tests/Feature/CompileParametersTest.php
@@ -134,4 +134,16 @@ class CompileParametersTest extends TestCase
         $this->assertCount(1, $parameters);
         $this->assertSame('-osTeSt', $parameters[0]);
     }
+
+    public function test_array_argument()
+    {
+        $task = factory(Task::class)->create();
+        $task->parameters = '--id=1 --id=2';
+        $parameters = $task->compileParameters(true);
+
+        $this->assertCount(1, $parameters);
+        $this->assertIsArray($parameters['--id']);
+        $this->assertSame('1', $parameters['--id'][0]);
+        $this->assertSame('2', $parameters['--id'][1]);
+    }
 }

--- a/tests/Feature/CompileParametersTest.php
+++ b/tests/Feature/CompileParametersTest.php
@@ -124,4 +124,14 @@ class CompileParametersTest extends TestCase
         $this->assertSame('yes', $parameters['--option']);
         $this->assertSame('warm', $parameters['--someplace']);
     }
+
+    public function test_single_dash()
+    {
+        $task = factory(Task::class)->create();
+        $task->parameters = '-osTeSt';
+        $parameters = $task->compileParameters(true);
+
+        $this->assertCount(1, $parameters);
+        $this->assertSame(true, $parameters['-osTeSt']);
+    }
 }

--- a/tests/Feature/CompileParametersTest.php
+++ b/tests/Feature/CompileParametersTest.php
@@ -132,6 +132,6 @@ class CompileParametersTest extends TestCase
         $parameters = $task->compileParameters(true);
 
         $this->assertCount(1, $parameters);
-        $this->assertSame(true, $parameters['-osTeSt']);
+        $this->assertSame('-osTeSt', $parameters[0]);
     }
 }


### PR DESCRIPTION
#146 Is fixed in this PR as we were not parsing/handling a single `-` when compiling parameters