### PR TITLE
Updating compile parameters to handle array arguments

### DIFF
--- a/src/Task.php
+++ b/src/Task.php
@@ -100,6 +100,7 @@ class Task extends TotemModel
                         } else {
                             $carry[$argument_index++] = $trimmed_param;
                         }
+
                         return $carry;
                     }
 
@@ -110,7 +111,6 @@ class Task extends TotemModel
                     $carry[$param[0]] = true :
                     $carry[$argument_index++] = $param[0];
             }, []);
-
         }
 
         return [];

--- a/src/Task.php
+++ b/src/Task.php
@@ -81,26 +81,36 @@ class Task extends TotemModel
             preg_match_all($regex, $this->parameters, $matches, PREG_SET_ORDER, 0);
 
             $argument_index = 0;
-            $parameters = collect($matches)->mapWithKeys(function ($parameter) use ($console, &$argument_index) {
+            $parameters = collect($matches)->reduce(function ($carry, $parameter) use ($console, &$argument_index) {
                 $param = explode('=', $parameter[0]);
 
                 if (count($param) > 1) {
                     $trimmed_param = trim(trim($param[1], '"'), "'");
                     if ($console) {
-                        return starts_with($param[0], ['--', '-']) ?
-                            [$param[0] => $trimmed_param] :
-                            [$argument_index++ => $trimmed_param];
+                        if (starts_with($param[0], ['--', '-'])) {
+                            if (!isset($carry[$param[0]])) {
+                                $carry[$param[0]] = $trimmed_param;
+                            } else {
+                                if (!is_array($carry[$param[0]])) {
+                                    $carry[$param[0]] = [$carry[$param[0]]];
+                                }
+                                $carry[$param[0]][] = $trimmed_param;
+                            }
+                            $carry[$param[0]] = $trimmed_param;
+                        } else {
+                            $carry[$argument_index++] = $trimmed_param;
+                        }
+                        return $carry;
                     }
 
-                    return [$param[0] => $trimmed_param];
+                    return $carry[$param[0]] = $trimmed_param;
                 }
 
                 return starts_with($param[0], ['--', '-']) && ! $console ?
-                    [$param[0] => true] :
-                    [$argument_index++ => $param[0]];
-            })->toArray();
+                    $carry[$param[0]] = true :
+                    $carry[$argument_index++] = $param[0];
+            }, []);
 
-            return $parameters;
         }
 
         return [];

--- a/src/Task.php
+++ b/src/Task.php
@@ -88,10 +88,10 @@ class Task extends TotemModel
                     $trimmed_param = trim(trim($param[1], '"'), "'");
                     if ($console) {
                         if (starts_with($param[0], ['--', '-'])) {
-                            if (!isset($carry[$param[0]])) {
+                            if (! isset($carry[$param[0]])) {
                                 $carry[$param[0]] = $trimmed_param;
                             } else {
-                                if (!is_array($carry[$param[0]])) {
+                                if (! is_array($carry[$param[0]])) {
                                     $carry[$param[0]] = [$carry[$param[0]]];
                                 }
                                 $carry[$param[0]][] = $trimmed_param;

--- a/src/Task.php
+++ b/src/Task.php
@@ -81,22 +81,28 @@ class Task extends TotemModel
             preg_match_all($regex, $this->parameters, $matches, PREG_SET_ORDER, 0);
 
             $argument_index = 0;
-            $parameters = collect($matches)->reduce(function ($carry, $parameter) use ($console, &$argument_index) {
+
+            $duplicate_parameter_index = function (array $carry, array $param, string $trimmed_param) {
+                if (! isset($carry[$param[0]])) {
+                    $carry[$param[0]] = $trimmed_param;
+                } else {
+                    if (! is_array($carry[$param[0]])) {
+                        $carry[$param[0]] = [$carry[$param[0]]];
+                    }
+                    $carry[$param[0]][] = $trimmed_param;
+                }
+
+                return $carry;
+            };
+
+            return collect($matches)->reduce(function ($carry, $parameter) use ($console, &$argument_index, $duplicate_parameter_index) {
                 $param = explode('=', $parameter[0]);
 
                 if (count($param) > 1) {
                     $trimmed_param = trim(trim($param[1], '"'), "'");
                     if ($console) {
                         if (starts_with($param[0], ['--', '-'])) {
-                            if (! isset($carry[$param[0]])) {
-                                $carry[$param[0]] = $trimmed_param;
-                            } else {
-                                if (! is_array($carry[$param[0]])) {
-                                    $carry[$param[0]] = [$carry[$param[0]]];
-                                }
-                                $carry[$param[0]][] = $trimmed_param;
-                            }
-                            $carry[$param[0]] = $trimmed_param;
+                            $carry = $duplicate_parameter_index($carry, $param, $trimmed_param);
                         } else {
                             $carry[$argument_index++] = $trimmed_param;
                         }
@@ -104,12 +110,14 @@ class Task extends TotemModel
                         return $carry;
                     }
 
-                    return $carry[$param[0]] = $trimmed_param;
+                    return $duplicate_parameter_index($carry, $param, $trimmed_param);
                 }
 
-                return starts_with($param[0], ['--', '-']) && ! $console ?
+                starts_with($param[0], ['--', '-']) && ! $console ?
                     $carry[$param[0]] = true :
                     $carry[$argument_index++] = $param[0];
+
+                return $carry;
             }, []);
         }
 

--- a/tests/Feature/CompileParametersTest.php
+++ b/tests/Feature/CompileParametersTest.php
@@ -145,6 +145,5 @@ class CompileParametersTest extends TestCase
         $this->assertIsArray($parameters['--id']);
         $this->assertSame('1', $parameters['--id'][0]);
         $this->assertSame('2', $parameters['--id'][1]);
-
     }
 }

--- a/tests/Feature/CompileParametersTest.php
+++ b/tests/Feature/CompileParametersTest.php
@@ -134,4 +134,17 @@ class CompileParametersTest extends TestCase
         $this->assertCount(1, $parameters);
         $this->assertSame('-osTeSt', $parameters[0]);
     }
+
+    public function test_array_argument()
+    {
+        $task = factory(Task::class)->create();
+        $task->parameters = '--id=1 --id=2';
+        $parameters = $task->compileParameters(true);
+
+        $this->assertCount(1, $parameters);
+        $this->assertIsArray($parameters['--id']);
+        $this->assertSame('1', $parameters['--id'][0]);
+        $this->assertSame('2', $parameters['--id'][1]);
+
+    }
 }


### PR DESCRIPTION
Laravel allows for command signatures like `--id=*` which can then pass multiple items like `command --id=1 --id=2`. This PR updates to handle that and fixes #191 