### PR TITLE
[Fix] Allow escaped equals characters in parameters

### DIFF
--- a/src/Task.php
+++ b/src/Task.php
@@ -97,10 +97,11 @@ class Task extends TotemModel
             };
 
             return collect($matches)->reduce(function ($carry, $parameter) use ($console, &$argument_index, $duplicate_parameter_index) {
-                $param = explode('=', $parameter[0]);
+                $param = preg_split("/(?<!\\\\)=/", $parameter[0]);
 
                 if (count($param) > 1) {
-                    $trimmed_param = trim(trim($param[1], '"'), "'");
+                    $escaped_param = str_replace('\\=', '=', $param[1]);
+                    $trimmed_param = trim(trim($escaped_param, '"'), "'");
                     if ($console) {
                         if (Str::startsWith($param[0], ['--', '-'])) {
                             $carry = $duplicate_parameter_index($carry, $param, $trimmed_param);

--- a/src/Task.php
+++ b/src/Task.php
@@ -4,10 +4,10 @@ namespace Studio\Totem;
 
 use Carbon\Carbon;
 use Cron\CronExpression;
-use Illuminate\Support\Str;
-use Studio\Totem\Traits\HasFrequencies;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Str;
 use Studio\Totem\Traits\FrontendSortable;
+use Studio\Totem\Traits\HasFrequencies;
 
 class Task extends TotemModel
 {
@@ -97,7 +97,7 @@ class Task extends TotemModel
             };
 
             return collect($matches)->reduce(function ($carry, $parameter) use ($console, &$argument_index, $duplicate_parameter_index) {
-                $param = preg_split("/(?<!\\\\)=/", $parameter[0]);
+                $param = preg_split('/(?<!\\\\)=/', $parameter[0]);
 
                 if (count($param) > 1) {
                     $escaped_param = str_replace('\\=', '=', $param[1]);

--- a/tests/Feature/CompileParametersTest.php
+++ b/tests/Feature/CompileParametersTest.php
@@ -146,4 +146,15 @@ class CompileParametersTest extends TestCase
         $this->assertSame('1', $parameters['--id'][0]);
         $this->assertSame('2', $parameters['--id'][1]);
     }
+
+    public function test_escaped_equals()
+    {
+        $task = factory(Task::class)->create();
+        $task->parameters = 'arg1=a\=b --option=c\=d';
+        $parameters = $task->compileParameters(true);
+
+        $this->assertCount(2, $parameters);
+        $this->assertSame('a=b', $parameters[0]);
+        $this->assertSame('c=d', $parameters['--option']);
+    }
 }


### PR DESCRIPTION
Due to the `explode()` function used when compiling parameters, it is not possible to have a paramater with an equals sign in it. 
eg: `url=http://example.com?page=test`

This patch allows users to escape the equals sign in the parameter by using a backslash. 

eg: `url=http://example.com?page\=test`