### PR TITLE
Fixing task_results task_id FK name in migration down method

### DIFF
--- a/database/migrations/2018_07_06_165603_add_indexes_for_tasks.php
+++ b/database/migrations/2018_07_06_165603_add_indexes_for_tasks.php
@@ -50,7 +50,7 @@ class AddIndexesForTasks extends TotemMigration
     {
         Schema::connection(TOTEM_DATABASE_CONNECTION)
             ->table(TOTEM_TABLE_PREFIX.'task_results', function (Blueprint $table) {
-                $table->dropForeign('task_results_task_id_fk');
+                $table->dropForeign('task_id_fk');
             });
         Schema::connection(TOTEM_DATABASE_CONNECTION)
             ->table(TOTEM_TABLE_PREFIX.'task_results', function (Blueprint $table) {


### PR DESCRIPTION
Migration down method currently fails because it's trying to remove a non-existing FK on the task_results table:

FK is created as `$table->foreign('task_id', 'task_id_fk')`

Which should probably have been `task_results_task_id_fk` in the first place, following the rest of the index names.

For now, `migrate:rollback` fails with:

> SQLSTATE[42000]: Syntax error or access violation: 1091 Can't DROP 'task_results_task_id_fk'; check that column/key exists (SQL: alter table `task_results` drop foreign key `task_results_task_id_fk`)

Renaming index name in `down()` method to match the one in `up()`.