### PR TITLE
Fix task results table migration error

### DIFF
--- a/database/migrations/2019_09_25_103421_update_task_results_duration_type.php
+++ b/database/migrations/2019_09_25_103421_update_task_results_duration_type.php
@@ -15,7 +15,7 @@ class UpdateTaskResultsDurationType extends TotemMigration
     {
         Schema::connection(TOTEM_DATABASE_CONNECTION)
             ->table(TOTEM_TABLE_PREFIX.'task_results', function (Blueprint $table) {
-                $table->decimal('duration', 24, 14)->change();
+                $table->decimal('duration', 24, 14)->charset('')->collation('')->change();
             });
     }
 

--- a/database/migrations/2019_09_25_103421_update_task_results_duration_type.php
+++ b/database/migrations/2019_09_25_103421_update_task_results_duration_type.php
@@ -1,7 +1,7 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 use Studio\Totem\Database\TotemMigration;
 
 class UpdateTaskResultsDurationType extends TotemMigration


### PR DESCRIPTION
What does this Pull Request Do?
-------------------------------
It updates the `2019_09_25_103421_update_task_results_duration_type.php` migration that produces the error `SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'CHARACTER SET utf8mb4 NOT NULL COLLATE utf8mb4_unicode_ci' at line 1 (SQL: ALTER TABLE totem_task_results CHANGE duration duration NUMERIC(24, 14) CHARACTER SET utf8mb4 NOT NULL COLLATE utf8mb4_unicode_ci)` when trying to run the migration.

How should this be manually tested?
-----------------------------------
- Just execute the `php artisan migrate` command and everything should be fine ;).

Any background context you want to provide?
-------------------------------------------
It seems that with the update of the `doctrine/dbal` package to the 2.10 version when a column is being changed to a specific new type of column it gets broken (mainly because it is setting the character set and the collate to a column that shouldn't have that set in the first place).

There is a big debate whether this is a Laravel bug or a Doctrine bug (these are the issues on each repo: https://github.com/doctrine/dbal/issues/3714 and https://github.com/laravel/framework/issues/30539 (this last one if where I got the solution from))

What is the relevant issue?
------------------------------
[migration error on alter duration](https://github.com/codestudiohq/laravel-totem/issues/204)

Any extra info?
---------------
![bacon](http://www.reactiongifs.com/r/kbs.gif)