### PR TITLE
use Illuminate\Support\Facades\Log instead of relying on alias

### DIFF
--- a/src/Providers/TotemServiceProvider.php
+++ b/src/Providers/TotemServiceProvider.php
@@ -4,6 +4,7 @@ namespace Studio\Totem\Providers;
 
 use Cron\CronExpression;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ServiceProvider;


### PR DESCRIPTION
In certain cases this can cause composer to throw an error because it doesn't know about the aliases yet.

```
Symfony\Component\Debug\Exception\FatalThrowableError  : Class 'Studio\Totem\Providers\Log' not found
```