### PR TITLE
[Proposal] feature: remove hard coded totem prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ Totem::auth(function($request) {
 
 By default Totem's dashboard only works in local environment. To view the dashboard point your browser to /totem of your app. For e.g. laravel.dev/totem.
 
+You can also change the route to which totem points to by changing `'totem.web.prefix`
+in the `config/totem.php` file 
+
 ##### Filter Commands Dropdown
 
 By default `Totem` outputs all Artisan commands on the Create/Edit tasks. To make this dropdown more concise there is a filter config feature that can be set in the `totem.php` config file.

--- a/config/totem.php
+++ b/config/totem.php
@@ -218,6 +218,7 @@ return [
     ],
     'web' => [
         'middleware' => env('TOTEM_WEB_MIDDLEWARE', 'web'),
+        'prefix'     => env('TOTEM_WEB_PREFIX', 'totem')
     ],
     'api' => [
         'middleware' => env('TOTEM_API_MIDDLEWARE', 'api'),

--- a/src/Providers/TotemRouteServiceProvider.php
+++ b/src/Providers/TotemRouteServiceProvider.php
@@ -54,7 +54,7 @@ class TotemRouteServiceProvider extends RouteServiceProvider
      */
     protected function mapWebRoutes()
     {
-        Route::prefix('totem')
+        Route::prefix(config('totem.web.prefix'))
             ->middleware(config('totem.web.middleware'))
             ->namespace($this->namespace)
             ->group(__DIR__.'/../../routes/web.php');


### PR DESCRIPTION
Issue - Totem prefix for web routes is hard coded and at times, projects can have different ways of implementing routes for security reasons . As such I believe setting and changing the prefix using the config file can be of added benefit to users of this package and toool