### PR TITLE
Postgres migration error 

### DIFF
--- a/database/migrations/2019_09_25_103421_update_task_results_duration_type.php
+++ b/database/migrations/2019_09_25_103421_update_task_results_duration_type.php
@@ -13,10 +13,11 @@ class UpdateTaskResultsDurationType extends TotemMigration
      */
     public function up()
     {
-        Schema::connection(TOTEM_DATABASE_CONNECTION)
+        /*Schema::connection(TOTEM_DATABASE_CONNECTION)
             ->table(TOTEM_TABLE_PREFIX.'task_results', function (Blueprint $table) {
                 $table->decimal('duration', 24, 14)->charset('')->collation('')->change();
-            });
+            });*/
+        \DB::connection(TOTEM_DATABASE_CONNECTION)->statement(" ALTER TABLE ". TOTEM_TABLE_PREFIX . "task_results ALTER duration TYPE NUMERIC(24, 14) USING duration::numeric(24,14) ");
     }
 
     /**


### PR DESCRIPTION
```
SQLSTATE[42804]: Datatype mismatch: 7 ERROR:  column "duration" cannot be cast automatically to type numeric
NOTA: You might need to specify "USING duration::numeric(24,14)". (SQL: ALTER TABLE task_results ALTER duration TYPE NUMERIC(24, 14))
