### PR TITLE
Fixed update_task_results_duration_type migration failed

### DIFF
--- a/database/migrations/2019_09_25_103421_update_task_results_duration_type.php
+++ b/database/migrations/2019_09_25_103421_update_task_results_duration_type.php
@@ -42,9 +42,9 @@ class UpdateTaskResultsDurationType extends TotemMigration
             ->table(TOTEM_TABLE_PREFIX.'task_results', function (Blueprint $table) use ($toFloat) {
                 // Create new decimal column
                 if ($toFloat) {
-                    $table->decimal('duration', 24, 14)->default(0.0)->charset('')->collation('');
+                    $table->decimal('duration_old', 24, 14)->default(0.0)->charset('')->collation('')->change();
                 } else {
-                    $table->string('duration')->default('');
+                    $table->string('duration_old')->default('');
                 }
             });
 


### PR DESCRIPTION
Err: 
```
SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'character set  collate '' not null default '0'' at line 1 (SQL: alter table `task_results` add `duration` decimal(24, 14) character set  collate '' not null default '0')
```

ss: https://ibb.co/znJ0Jyd