### PR TITLE
[fix] remove methods causing migration failure on mysql 8

### DIFF
--- a/database/migrations/2019_09_25_103421_update_task_results_duration_type.php
+++ b/database/migrations/2019_09_25_103421_update_task_results_duration_type.php
@@ -42,7 +42,7 @@ class UpdateTaskResultsDurationType extends TotemMigration
             ->table(TOTEM_TABLE_PREFIX.'task_results', function (Blueprint $table) use ($toFloat) {
                 // Create new decimal column
                 if ($toFloat) {
-                    $table->decimal('duration', 24, 14)->default(0.0)->charset('')->collation('');
+                    $table->decimal('duration', 24, 14)->default(0.0);
                 } else {
                     $table->string('duration')->default('');
                 }

--- a/tests/Feature/ViewDashboardTest.php
+++ b/tests/Feature/ViewDashboardTest.php
@@ -2,12 +2,15 @@
 
 namespace Studio\Totem\Tests\Feature;
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Studio\Totem\Result;
 use Studio\Totem\Task;
 use Studio\Totem\Tests\TestCase;
 
 class ViewDashboardTest extends TestCase
 {
+    use RefreshDatabase;
+
     /** @test */
     public function user_can_view_dashboard()
     {


### PR DESCRIPTION
@qschmick, @roshangautam : This PR (after closing the messy commit history of the previous one), fixes the current issue with migrations failing on MySQL 8 in 2019_09_25_103421_update_task_results_duration_type.php. Also added the RefreshDatabase trait to ViewDashboardTest as the tests fail without this.