### PR TITLE
Allow running tasks concurrently with runInBackground()

### DIFF
--- a/config/totem.php
+++ b/config/totem.php
@@ -228,6 +228,8 @@ return [
         'whitelist' => true,
     ],
     'database_connection' => env('TOTEM_DATABASE_CONNECTION'),
+        
+    'run_in_background' => env('TOTEM_RUN_IN_BACKGROUND', false),
 
     'broadcasting' => [
         'enabled' => env('TOTEM_BROADCASTING_ENABLED', true),

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -44,14 +44,21 @@ class ConsoleServiceProvider extends ServiceProvider
                     Executed::dispatch($task, $event->start);
                 })
                 ->sendOutputTo(storage_path($task->getMutexName()));
+            
             if ($task->dont_overlap) {
                 $event->withoutOverlapping();
             }
+            
             if ($task->run_in_maintenance) {
                 $event->evenInMaintenanceMode();
             }
+            
             if ($task->run_on_one_server && in_array(config('cache.default'), ['memcached', 'redis'])) {
                 $event->onOneServer();
+            }
+            
+            if (config('totem.run_in_background', false)) {
+                $event->runInBackground();
             }
         });
     }


### PR DESCRIPTION
Laravel now allows you to launch tasks concurrently via the `runInBackground()` command. Without it, if you have many tasks scheduled for the top of the hour, you may be delayed in launching some by several minutes. This should help alleviate that issue.

https://laravel.com/docs/8.x/scheduling#background-tasks

I have made this option opt-in so it is backwards compatible (default off). There aren't any known issues that I know of, except for possibly a higher memory / cpu utilization if launching many forked processes all at once instead of sequentially like the current behavior.