### PR TITLE
Use Storage facade instead of php file functions

### DIFF
--- a/src/Events/Executed.php
+++ b/src/Events/Executed.php
@@ -2,6 +2,7 @@
 
 namespace Studio\Totem\Events;
 
+use Illuminate\Support\Facades\Storage;
 use Studio\Totem\Notifications\TaskCompleted;
 use Studio\Totem\Task;
 
@@ -19,15 +20,15 @@ class Executed extends BroadcastingEvent
 
         $time_elapsed_secs = microtime(true) - $started;
 
-        if (file_exists(storage_path($task->getMutexName()))) {
-            $output = file_get_contents(storage_path($task->getMutexName()));
+        if (Storage::exists(storage_path($task->getMutexName()))) {
+            $output = Storage::get(storage_path($task->getMutexName()));
 
             $task->results()->create([
                 'duration'  => $time_elapsed_secs * 1000,
                 'result'    => $output,
             ]);
 
-            unlink(storage_path($task->getMutexName()));
+            Storage::delete(storage_path($task->getMutexName()));
 
             $task->notify(new TaskCompleted($output));
             $task->autoCleanup();

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -41,7 +41,7 @@ class ConsoleServiceProvider extends ServiceProvider
                     Executing::dispatch($task);
                 })
                 ->after(function () use ($event, $task) {
-                    Executed::dispatch($task, $event->start);
+                    Executed::dispatch($task, $event->start ?? microtime(true));
                 })
                 ->sendOutputTo(storage_path($task->getMutexName()));
             if ($task->dont_overlap) {

--- a/src/Repositories/EloquentTaskRepository.php
+++ b/src/Repositories/EloquentTaskRepository.php
@@ -18,6 +18,7 @@ use Studio\Totem\Events\Updated;
 use Studio\Totem\Events\Updating;
 use Studio\Totem\Result;
 use Studio\Totem\Task;
+use Illuminate\Support\Facades\Storage;
 
 class EloquentTaskRepository implements TaskInterface
 {
@@ -195,9 +196,9 @@ class EloquentTaskRepository implements TaskInterface
         try {
             Artisan::call($task->command, $task->compileParameters());
 
-            file_put_contents(storage_path($task->getMutexName()), Artisan::output());
+            Storage::put(storage_path($task->getMutexName()), Artisan::output());
         } catch (\Exception $e) {
-            file_put_contents(storage_path($task->getMutexName()), $e->getMessage());
+            Storage::put(storage_path($task->getMutexName()), $e->getMessage());
         }
 
         Executed::dispatch($task, $start);

--- a/src/Repositories/EloquentTaskRepository.php
+++ b/src/Repositories/EloquentTaskRepository.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
 use Studio\Totem\Contracts\TaskInterface;
 use Studio\Totem\Events\Activated;
 use Studio\Totem\Events\Created;
@@ -18,7 +19,6 @@ use Studio\Totem\Events\Updated;
 use Studio\Totem\Events\Updating;
 use Studio\Totem\Result;
 use Studio\Totem\Task;
-use Illuminate\Support\Facades\Storage;
 
 class EloquentTaskRepository implements TaskInterface
 {


### PR DESCRIPTION
This will account for different local filesystems.
Currently totem fails using laravel vapor because AWS lambda uses no local filesystem (only s3), yet the code assumes there is. 
Rather use the Storage facade so to use the laravel application's chosen filesystem