### PR TITLE
Updating driver support for onOneServer

### DIFF
--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -50,7 +50,7 @@ class ConsoleServiceProvider extends ServiceProvider
             if ($task->run_in_maintenance) {
                 $event->evenInMaintenanceMode();
             }
-            if ($task->run_on_one_server && in_array(config('cache.default'), ['memcached', 'redis'])) {
+            if ($task->run_on_one_server && in_array(config('cache.default'), ['memcached', 'redis', 'database', 'dynamodb'])) {
                 $event->onOneServer();
             }
             if ($task->run_in_background) {


### PR DESCRIPTION
Per the documentation: https://laravel.com/docs/8.x/scheduling#running-tasks-on-one-server

You should be able to use onOneServer() when using the database and dynamodb application cache driver, but it's currently not supported here. Adding these options into the ConsoleServiceProvider.