### PR TITLE
Laravel 8 fix

### DIFF
--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\ServiceProvider;
 use Studio\Totem\Events\Executed;
 use Studio\Totem\Events\Executing;
+use Studio\Totem\Totem;
 
 class ConsoleServiceProvider extends ServiceProvider
 {
@@ -17,9 +18,11 @@ class ConsoleServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->app->resolving(Schedule::class, function ($schedule) {
-            $this->schedule($schedule);
-        });
+        if (Totem::baseTableExists()) {
+            $this->app->resolving(Schedule::class, function ($schedule) {
+                $this->schedule($schedule);
+            });
+        }
     }
 
     /**

--- a/src/Providers/TotemServiceProvider.php
+++ b/src/Providers/TotemServiceProvider.php
@@ -4,7 +4,6 @@ namespace Studio\Totem\Providers;
 
 use Cron\CronExpression;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ServiceProvider;
@@ -12,7 +11,6 @@ use Studio\Totem\Console\Commands\ListSchedule;
 use Studio\Totem\Console\Commands\PublishAssets;
 use Studio\Totem\Contracts\TaskInterface;
 use Studio\Totem\Repositories\EloquentTaskRepository;
-use Studio\Totem\Totem;
 
 class TotemServiceProvider extends ServiceProvider
 {

--- a/src/Providers/TotemServiceProvider.php
+++ b/src/Providers/TotemServiceProvider.php
@@ -23,14 +23,6 @@ class TotemServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        try {
-            if (Totem::baseTableExists()) {
-                $this->app->register(ConsoleServiceProvider::class);
-            }
-        } catch (\PDOException $ex) {
-            // This will trigger if DB cannot be connected to
-            Log::error($ex->getMessage());
-        }
         $this->registerResources();
         $this->defineAssetPublishing();
 
@@ -77,6 +69,7 @@ class TotemServiceProvider extends ServiceProvider
         $this->app->register(TotemRouteServiceProvider::class);
         $this->app->register(TotemEventServiceProvider::class);
         $this->app->register(TotemFormServiceProvider::class);
+        $this->app->register(ConsoleServiceProvider::class);
     }
 
     /**

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -32,7 +32,8 @@ class AuthTest extends TestCase
         $middleware = new Authenticate;
 
         $response = $middleware->handle(
-            new class {
+            new class
+            {
             },
             function ($value) {
                 return 'response';
@@ -55,7 +56,8 @@ class AuthTest extends TestCase
         $middleware = new Authenticate;
 
         $response = $middleware->handle(
-            new class {
+            new class
+            {
             },
             function ($value) {
                 return 'response';

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -74,7 +74,8 @@ class TestCase extends \Orchestra\Testbench\TestCase
      */
     protected function disableExceptionHandling()
     {
-        $this->app->instance(ExceptionHandler::class, new class() extends Handler {
+        $this->app->instance(ExceptionHandler::class, new class() extends Handler
+        {
             public function __construct()
             {
             }


### PR DESCRIPTION
Laravel 8.x treats the order of registration differently. This change properly registers the Console Service Provider so schedule tasks will run correctly and the `schedule:list` command will work