### PR TITLE
Add in the ability to disable database calls on registering

### DIFF
--- a/config/totem.php
+++ b/config/totem.php
@@ -236,4 +236,6 @@ return [
     ],
 
     'log_folder' => env('TOTEM_LOG_FOLDER', 'totem'),
+
+    'schedule_enabled' => env('TOTEM_SCHEDULE_ENABLED', true)
 ];

--- a/config/totem.php
+++ b/config/totem.php
@@ -237,5 +237,5 @@ return [
 
     'log_folder' => env('TOTEM_LOG_FOLDER', 'totem'),
 
-    'schedule_enabled' => env('TOTEM_SCHEDULE_ENABLED', true)
+    'schedule_enabled' => env('TOTEM_SCHEDULE_ENABLED', true),
 ];

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -18,7 +18,7 @@ class ConsoleServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        if (Totem::baseTableExists()) {
+        if (config('totem.schedule_enabled', true) && Totem::baseTableExists()) {
             $this->app->resolving(Schedule::class, function ($schedule) {
                 $this->schedule($schedule);
             });


### PR DESCRIPTION
I'm currently having issues installing this package on my dev environment because it doesn't host the database. We have a pretty unique way of setting up our dev system and it's hosted on a remote server to which my local doesn't have access.

It would be nice to be able to install this package on my local and disable the table exists lookup, whilst when actually running it on my actual server it will run normally. 

I've tried to take into account BCs in this PR and it shouldn't break any existing apps. 

Thoughts? 