### PR TITLE
Replace use of storage logs by passing output to events

### DIFF
--- a/config/totem.php
+++ b/config/totem.php
@@ -234,6 +234,4 @@ return [
         'enabled' => env('TOTEM_BROADCASTING_ENABLED', true),
         'channel' => env('TOTEM_BROADCASTING_CHANNEL', 'task.events'),
     ],
-
-    'log_folder' => env('TOTEM_LOG_FOLDER', 'totem'),
 ];

--- a/src/Repositories/EloquentTaskRepository.php
+++ b/src/Repositories/EloquentTaskRepository.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Storage;
 use Studio\Totem\Contracts\TaskInterface;
 use Studio\Totem\Events\Activated;
 use Studio\Totem\Events\Created;
@@ -195,13 +194,12 @@ class EloquentTaskRepository implements TaskInterface
         $start = microtime(true);
         try {
             Artisan::call($task->command, $task->compileParameters());
-
-            Storage::put($task->getMutexName(), Artisan::output());
+            $output = Artisan::output();
         } catch (\Exception $e) {
-            Storage::put($task->getMutexName(), $e->getMessage());
+            $output = $e->getMessage();
         }
 
-        Executed::dispatch($task, $start);
+        Executed::dispatch($task, $start, $output);
 
         return $task;
     }

--- a/src/Traits/HasFrequencies.php
+++ b/src/Traits/HasFrequencies.php
@@ -117,16 +117,6 @@ trait HasFrequencies
     }
 
     /**
-     * Get the mutex name for the scheduled task.
-     *
-     * @return string
-     */
-    public function getMutexName()
-    {
-        return config('totem.log_folder').DIRECTORY_SEPARATOR.'schedule-'.sha1($this->expression.$this->command.$this->parameters);
-    }
-
-    /**
      * Determine if the filters pass for the event.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app


### PR DESCRIPTION
This replace the use of storage files by passing the console output directly to the events. The log folder and `getMutexName` method are also removed since they aren't used anywhere else.

Closes #295