### PR TITLE
[Fix] Exceptions handling in initialization

### DIFF
--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -17,7 +17,7 @@ class ConsoleServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        if (Totem::baseTableExists()) {
+        if (Totem::isEnabled()) {
             $this->app->resolving(Schedule::class, function ($schedule) {
                 $this->schedule($schedule);
             });

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -27,7 +27,7 @@ class ConsoleServiceProvider extends ServiceProvider
     /**
      * Prepare schedule from tasks.
      *
-     * @param Schedule $schedule
+     * @param  Schedule  $schedule
      */
     public function schedule(Schedule $schedule)
     {

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -17,11 +17,11 @@ class ConsoleServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        if (Totem::isEnabled()) {
-            $this->app->resolving(Schedule::class, function ($schedule) {
+        $this->app->resolving(Schedule::class, function ($schedule) {
+            if (Totem::isEnabled()) {
                 $this->schedule($schedule);
-            });
-        }
+            }
+        });
     }
 
     /**

--- a/src/Totem.php
+++ b/src/Totem.php
@@ -21,7 +21,7 @@ class Totem
     /**
      * Determine if the given request can access the Totem dashboard.
      *
-     * @param \Illuminate\Http\Request $request
+     * @param  \Illuminate\Http\Request  $request
      *
      * @return bool
      */
@@ -35,7 +35,7 @@ class Totem
     /**
      * Set the callback that should be used to authenticate Totem users.
      *
-     * @param \Closure $callback
+     * @param  \Closure  $callback
      *
      * @return static
      */

--- a/src/Totem.php
+++ b/src/Totem.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Schema;
 use Symfony\Component\Console\Command\Command;
+use Throwable;
 
 class Totem
 {
@@ -91,16 +92,20 @@ class Totem
     /**
      * @return bool
      */
-    public static function baseTableExists(): bool
+    public static function isEnabled(): bool
     {
-        if (Cache::get('totem.table.'.TOTEM_TABLE_PREFIX.'tasks')) {
-            return true;
-        }
+        try {
+            if (Cache::get('totem.table.'.TOTEM_TABLE_PREFIX.'tasks')) {
+                return true;
+            }
 
-        if (Schema::hasTable(TOTEM_TABLE_PREFIX.'tasks')) {
-            Cache::forever('totem.table.'.TOTEM_TABLE_PREFIX.'tasks', true);
+            if (Schema::hasTable(TOTEM_TABLE_PREFIX.'tasks')) {
+                Cache::forever('totem.table.'.TOTEM_TABLE_PREFIX.'tasks', true);
 
-            return true;
+                return true;
+            }
+        } catch (Throwable $e) {
+            return false;
         }
 
         return false;


### PR DESCRIPTION
In cases where the cache or DB are offline, totem would throw an exception and prevent the app from bootstrapping.
Totem should be disabled in those cases and let the app how it knows (other services might have cache fallbacks or specific error handling).

* Added exceptions handling for cache/DB
* Refactored `baseTableExists()` to `isEnabled()`
* Move `isEnabled()` call inside the resolving callback function to prevent calling DB and Cache in every app bootstrap, so now it runs only when Schedule is constructed (only in console kernel)
