### PR TITLE
Cache Task frequencies

### DIFF
--- a/src/Repositories/EloquentTaskRepository.php
+++ b/src/Repositories/EloquentTaskRepository.php
@@ -54,7 +54,7 @@ class EloquentTaskRepository implements TaskInterface
         }
 
         return Cache::rememberForever('totem.task.'.$id, function () use ($id) {
-            return Task::find($id);
+            return Task::query()->with("frequencies")->find($id);
         });
     }
 
@@ -66,7 +66,7 @@ class EloquentTaskRepository implements TaskInterface
     public function findAll()
     {
         return Cache::rememberForever('totem.tasks.all', function () {
-            return Task::all();
+            return Task::query()->with("frequencies")->get();
         });
     }
 

--- a/src/Repositories/EloquentTaskRepository.php
+++ b/src/Repositories/EloquentTaskRepository.php
@@ -54,7 +54,7 @@ class EloquentTaskRepository implements TaskInterface
         }
 
         return Cache::rememberForever('totem.task.'.$id, function () use ($id) {
-            return Task::query()->with("frequencies")->find($id);
+            return Task::query()->with('frequencies')->find($id);
         });
     }
 
@@ -66,7 +66,7 @@ class EloquentTaskRepository implements TaskInterface
     public function findAll()
     {
         return Cache::rememberForever('totem.tasks.all', function () {
-            return Task::query()->with("frequencies")->get();
+            return Task::query()->with('frequencies')->get();
         });
     }
 


### PR DESCRIPTION
Cache also the tasks frequencies, so they won't be queried in every schedule registration

Currently it get all tasks from cache, the performs `$task->getCronExpression()`.
The getCronExpression() queries the related frequencies, in a foreach, without lazy loading, it means we are making an N+1 error

an example can be 
https://github.com/codestudiohq/laravel-totem/issues/301