### PR TITLE
Fix Laravel 9 test runner

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,18 +19,18 @@
     "php": "^8.0.0|^8.1.0",
     "ext-json": "*",
     "doctrine/dbal": "^3.1",
-    "illuminate/bus": "^8.11",
-    "illuminate/console": "^8.11",
-    "illuminate/contracts": "^8.11",
-    "illuminate/database": "^8.11",
-    "illuminate/events": "^8.11",
-    "illuminate/notifications": "^8.11",
+    "illuminate/bus": "^8.11|^9.0",
+    "illuminate/console": "^8.11|^9.0",
+    "illuminate/contracts": "^8.11|^9.0",
+    "illuminate/database": "^8.11|^9.0",
+    "illuminate/events": "^8.11|^9.0",
+    "illuminate/notifications": "^8.11|^9.0",
     "laravelcollective/html": "^6.0"
   },
   "require-dev": {
     "mockery/mockery": "^1.0",
-    "orchestra/database": "^6.0",
-    "orchestra/testbench" : "^6.0",
+    "orchestra/database": "^6.0|^7.0",
+    "orchestra/testbench" : "^6.0|^7.0",
     "phpunit/phpunit": "^9.0"
   },
   "suggest": {

--- a/src/Contracts/TaskInterface.php
+++ b/src/Contracts/TaskInterface.php
@@ -21,7 +21,7 @@ interface TaskInterface
      * @param  int|Task  $id
      * @return Task
      */
-    public function find(Task|int $id): Task;
+    public function find(Task|int $id);
 
     /**
      * Returns all tasks.

--- a/src/Http/Middleware/Authenticate.php
+++ b/src/Http/Middleware/Authenticate.php
@@ -16,7 +16,7 @@ class Authenticate
      * @param  Closure  $next
      * @return Response
      */
-    public function handle(Request $request, Closure $next): Response
+    public function handle($request, $next)
     {
         return Totem::check($request) ? $next($request) : abort(403);
     }

--- a/src/Http/Requests/ImportRequest.php
+++ b/src/Http/Requests/ImportRequest.php
@@ -70,7 +70,7 @@ class ImportRequest extends FormRequest
      * @return array
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
-    public function validated()
+    public function validated($key = null, $default = null)
     {
         $content = '';
 

--- a/src/Repositories/EloquentTaskRepository.php
+++ b/src/Repositories/EloquentTaskRepository.php
@@ -48,7 +48,7 @@ class EloquentTaskRepository implements TaskInterface
      * @param  int|Task  $id
      * @return Task
      */
-    public function find(Task|int $id): Task
+    public function find(Task|int $id)
     {
         if ($id instanceof Task) {
             return $id;

--- a/src/Totem.php
+++ b/src/Totem.php
@@ -23,10 +23,10 @@ class Totem
     /**
      * Determine if the given request can access the Totem dashboard.
      *
-     * @param  Request  $request
+     * @param  Request|string|null  $request
      * @return bool
      */
-    public static function check(Request $request): bool
+    public static function check($request): bool
     {
         return (static::$authUsing ?: function () {
             return app()->environment('local');

--- a/tests/Feature/TaskExecutionTest.php
+++ b/tests/Feature/TaskExecutionTest.php
@@ -43,8 +43,6 @@ class TaskExecutionTest extends TestCase
 
         Event::fake();
 
-        $this->withoutExceptionHandling();
-
         $this->signIn()
             ->get(route('totem.task.execute', $task->id))
             ->assertSuccessful();

--- a/tests/Feature/TaskExecutionTest.php
+++ b/tests/Feature/TaskExecutionTest.php
@@ -43,7 +43,10 @@ class TaskExecutionTest extends TestCase
 
         Event::fake();
 
-        $this->get(route('totem.task.execute', $task->id))
+        $this->withoutExceptionHandling();
+
+        $this->signIn()
+            ->get(route('totem.task.execute', $task->id))
             ->assertSuccessful();
 
         $this->assertEquals(1, Result::count());


### PR DESCRIPTION
I've got the test runner to work against Laravel 9 now I have made the following changes:

- Updated composer to allow 9.x packages
- Updated validated to match 9.x signature 
- Reverted some typed elements as it was breaking the tests.

I do think looking at your PR it might be worth reverting all parameter/return types changes, especially in the contracts as this would be a breaking change.

Looks like I don't have access to run the tests against this repo, Here is mine: https://github.com/JamesFreeman/laravel-totem/runs/5403882721?check_suite_focus=true