### PR TITLE
Updated to pluck ids and perform delete using the ids

### DIFF
--- a/src/Task.php
+++ b/src/Task.php
@@ -192,26 +192,38 @@ class Task extends TotemModel
     {
         if ($this->auto_cleanup_num > 0) {
             if ($this->auto_cleanup_type === 'results') {
-                $oldest_id = self::results()
+                $oldest_id = $this->results()
                     ->orderBy('ran_at', 'desc')
                     ->limit($this->auto_cleanup_num)
                     ->get()
                     ->min('id');
                 do {
-                    $rowsDeleted = self::results()
+                    $rowsToDelete = $this->results()
                         ->where('id', '<', $oldest_id)
-                        ->limit(500)
+                        ->limit(50)
                         ->getQuery()
+                        ->select('id')
+                        ->pluck('id');
+
+                    Result::query()
+                        ->whereIn('id', $rowsToDelete)
                         ->delete();
-                } while ($rowsDeleted > 0);
+
+                } while ($rowsToDelete > 0);
             } else {
                 do {
-                    $rowsDeleted = self::results()
+                    $rowsToDelete = $this->results()
                         ->where('ran_at', '<', Carbon::now()->subDays($this->auto_cleanup_num - 1))
-                        ->limit(500)
+                        ->limit(50)
                         ->getQuery()
+                        ->select('id')
+                        ->pluck('id');
+
+                    Result::query()
+                        ->whereIn('id', $rowsToDelete)
                         ->delete();
-                } while ($rowsDeleted > 0);
+
+                } while ($rowsToDelete > 0);
             }
         }
     }

--- a/src/Task.php
+++ b/src/Task.php
@@ -208,7 +208,6 @@ class Task extends TotemModel
                     Result::query()
                         ->whereIn('id', $rowsToDelete)
                         ->delete();
-
                 } while ($rowsToDelete > 0);
             } else {
                 do {
@@ -222,7 +221,6 @@ class Task extends TotemModel
                     Result::query()
                         ->whereIn('id', $rowsToDelete)
                         ->delete();
-
                 } while ($rowsToDelete > 0);
             }
         }


### PR DESCRIPTION
Updated delete process to leverage a select of `id` only and then leverage that `id` to delete explicit rows as the scan over the table with large `result` values can cause long running delete calls.