### PR TITLE
Fix task_results created_at index name in migration down method

### DIFF
--- a/database/migrations/2022_03_14_120000_alter_task_results_table_add_index_on_created_at.php
+++ b/database/migrations/2022_03_14_120000_alter_task_results_table_add_index_on_created_at.php
@@ -28,7 +28,7 @@ class AlterTaskResultsTableAddIndexOnCreatedAt extends TotemMigration
     {
         Schema::connection(TOTEM_DATABASE_CONNECTION)
             ->table(TOTEM_TABLE_PREFIX.'task_results', function (Blueprint $table) {
-                $table->dropIndex('task_results_created_at_index');
+                $table->dropIndex(TOTEM_TABLE_PREFIX.'task_results_created_at_index');
             });
     }
 }

--- a/database/migrations/2022_03_14_120000_alter_task_results_table_add_index_on_created_at.php
+++ b/database/migrations/2022_03_14_120000_alter_task_results_table_add_index_on_created_at.php
@@ -28,7 +28,7 @@ class AlterTaskResultsTableAddIndexOnCreatedAt extends TotemMigration
     {
         Schema::connection(TOTEM_DATABASE_CONNECTION)
             ->table(TOTEM_TABLE_PREFIX.'task_results', function (Blueprint $table) {
-                $table->dropIndex('created_at');
+                $table->dropIndex('task_results_created_at_index');
             });
     }
 }


### PR DESCRIPTION
Migration down currently fails because the index name is incorrect:

> SQLSTATE[42000]: Syntax error or access violation: 1091 Can't DROP 'created_at'; check that column/key exists (SQL: alter table `task_results` drop index `created_at`)

Laravel automatically names the index to `task_results_created_at_index` in the up method