### PR TITLE
Add a configuration variable to choose the environment that totem

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ php artisan totem:assets
 
 Totems' tables use generic names which may conflict with existing tables in a project. To alleviate this the `.env` param `TOTEM_TABLE_PREFIX` can be set which will apply a prefix to all of Totems tables and their models.
 
+##### Environments
+
+By default, totem will set all scheduled tasks to run in the 'production' environment. This could be an issue if you have the artisan scheduler running on multiple servers with different environments. If you wish to override and specify which environments totem scheduled tasks run in you can add them to the .env param `TOTEM_ENVIRONMENTS`. This parameter accepts a comma separated list e.g. `production,staging`.
+
 #### Updating
 
 Please republish totem assets after updating totem to a new version

--- a/config/totem.php
+++ b/config/totem.php
@@ -229,7 +229,7 @@ return [
         'whitelist' => true,
     ],
     'database_connection' => env('TOTEM_DATABASE_CONNECTION'),
-
+    'environments' => implode(',', env('TOTEM_ENVIRONMENTS', 'production')),
     'broadcasting' => [
         'enabled' => env('TOTEM_BROADCASTING_ENABLED', true),
         'channel' => env('TOTEM_BROADCASTING_CHANNEL', 'task.events'),

--- a/config/totem.php
+++ b/config/totem.php
@@ -229,7 +229,7 @@ return [
         'whitelist' => true,
     ],
     'database_connection' => env('TOTEM_DATABASE_CONNECTION'),
-    'environments' => implode(',', env('TOTEM_ENVIRONMENTS', 'production')),
+    'environments' => explode(',', env('TOTEM_ENVIRONMENTS', 'production')),
     'broadcasting' => [
         'enabled' => env('TOTEM_BROADCASTING_ENABLED', true),
         'channel' => env('TOTEM_BROADCASTING_CHANNEL', 'task.events'),

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -34,7 +34,9 @@ class ConsoleServiceProvider extends ServiceProvider
         $tasks = app('totem.tasks')->findAllActive();
 
         $tasks->each(function ($task) use ($schedule) {
-            $event = $schedule->command($task->command, $task->compileParameters(true));
+            $event = $schedule
+                ->command($task->command, $task->compileParameters(true))
+                ->environments(config('totem.environments'));
 
             $event->cron($task->getCronExpression())
                 ->name($task->description)


### PR DESCRIPTION
Add a configuration variable to choose the environment that totem will set its scheduled tasks to run in.

We found that not being able to choose the environment that all totem tasks run in can cause duplication when trying to use the scheduler across different environments. This simple fix will allow users to customise the environment therefore ensuring that totem tasks only run where they are supposed to when multiple schedulers are running in our infrastructure and project. In our use case we would be setting this to 'production' so that non of our staging or development schedulers double up on the running of tasks.