### PR TITLE
[fix] job too big in task completed

### DIFF
--- a/src/Events/Executed.php
+++ b/src/Events/Executed.php
@@ -19,12 +19,12 @@ class Executed extends BroadcastingEvent
 
         $time_elapsed_secs = microtime(true) - $started;
 
-        $task->results()->create([
+        $result = $task->results()->create([
             'duration'  => $time_elapsed_secs * 1000,
             'result'    => $output,
         ]);
 
-        $task->notify(new TaskCompleted($output));
+        $task->notify(new TaskCompleted($result));
         $task->autoCleanup();
     }
 }

--- a/src/Notifications/TaskCompleted.php
+++ b/src/Notifications/TaskCompleted.php
@@ -9,22 +9,24 @@ use Illuminate\Notifications\Messages\NexmoMessage;
 use Illuminate\Notifications\Messages\SlackAttachment;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
+use Illuminate\Queue\SerializesModels;
+use Studio\Totem\Result;
 
 class TaskCompleted extends Notification implements ShouldQueue
 {
     use Queueable;
 
     /**
-     * @var
+     * @var Result
      */
-    private $output;
+    private $result;
 
     /**
      * Create a new notification instance.
      */
-    public function __construct($output)
+    public function __construct($result)
     {
-        $this->output = $output;
+        $this->result = $result;
     }
 
     /**
@@ -61,7 +63,7 @@ class TaskCompleted extends Notification implements ShouldQueue
                     ->subject($notifiable->description)
                     ->greeting('Hi,')
                     ->line("{$notifiable->description} just finished running.")
-                    ->line($this->output);
+                    ->line($this->result->result);
     }
 
     /**

--- a/src/Notifications/TaskCompleted.php
+++ b/src/Notifications/TaskCompleted.php
@@ -9,7 +9,6 @@ use Illuminate\Notifications\Messages\NexmoMessage;
 use Illuminate\Notifications\Messages\SlackAttachment;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
-use Illuminate\Queue\SerializesModels;
 use Studio\Totem\Result;
 
 class TaskCompleted extends Notification implements ShouldQueue


### PR DESCRIPTION
Each time when a task is executed, we firing `TaskCompleted` notification asynchronously with the output.
Sometimes (according to the artisan command type), the result might be very big and might lead to exceptions from the queue system.

we can fix it by not queuing the raw output, but queue the Result model itself (with SerializesModels) and receive the output from the model.