### PR TITLE
Fix Database Connection in Totem Enabled Check

### DIFF
--- a/src/Totem.php
+++ b/src/Totem.php
@@ -99,7 +99,7 @@ class Totem
                 return true;
             }
 
-            if (Schema::hasTable(TOTEM_TABLE_PREFIX.'tasks')) {
+            if (Schema::connection(TOTEM_DATABASE_CONNECTION)->hasTable(TOTEM_TABLE_PREFIX.'tasks')) {
                 Cache::forever('totem.table.'.TOTEM_TABLE_PREFIX.'tasks', true);
 
                 return true;


### PR DESCRIPTION
The Totem::isEnabled function doesn't respect the TOTEM_DATABASE_CONNECTION configuration option. This PR corrects the schema connection for the table check.