### PR TITLE
support Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
     "php": "^8.1.0",
     "ext-json": "*",
     "doctrine/dbal": "^3.1",
-    "illuminate/bus": "^9.0|^10.0|^11.0",
-    "illuminate/console": "^9.0|^10.0|^11.0",
-    "illuminate/contracts": "^9.0|^10.0|^11.0",
-    "illuminate/database": "^9.0|^10.0|^11.0",
-    "illuminate/events": "^9.0|^10.0|^11.0",
-    "illuminate/notifications": "^9.0|^10.0|^11.0"
+    "illuminate/bus": "^9.0|^10.0|^11.0|^12.0",
+    "illuminate/console": "^9.0|^10.0|^11.0|^12.0",
+    "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0",
+    "illuminate/database": "^9.0|^10.0|^11.0|^12.0",
+    "illuminate/events": "^9.0|^10.0|^11.0|^12.0",
+    "illuminate/notifications": "^9.0|^10.0|^11.0|^12.0"
   },
   "require-dev": {
     "mockery/mockery": "^1.0",


### PR DESCRIPTION
Just putting this out there to get ahead of the curve on supporting Laravel 12 when it's released on 24th Feb 2025.