### PR TITLE
Do not use Route root namespace facade

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Facades\Route;
+
 /*
 |--------------------------------------------------------------------------
 | Web Routes


### PR DESCRIPTION
root namespace facades are optional and can be disabled on app level. It's preferable to use facades by their real FQCNs as they are available in any app for sure, e.g. `Illuminate\Support\Facades\Route`


prevents errors like this:

![CleanShot 2025-02-07 at 23 30 58@2x](https://github.com/user-attachments/assets/1c857c86-f101-4a8a-bcfd-ae78cf1f02d8)
 