### PR TITLE
Fix migrate:rollback for SQLite

### DIFF
--- a/database/migrations/2018_07_06_165603_add_indexes_for_tasks.php
+++ b/database/migrations/2018_07_06_165603_add_indexes_for_tasks.php
@@ -48,19 +48,22 @@ class AddIndexesForTasks extends TotemMigration
      */
     public function down()
     {
-        Schema::connection(TOTEM_DATABASE_CONNECTION)
-            ->table(TOTEM_TABLE_PREFIX.'task_results', function (Blueprint $table) {
-                $table->dropForeign('task_id_fk');
-            });
+        if (Schema::getConnection()->getDriverName() !== 'sqlite') {
+            Schema::connection(TOTEM_DATABASE_CONNECTION)
+                ->table(TOTEM_TABLE_PREFIX.'task_results', function (Blueprint $table) {
+                    $table->dropForeign('task_id_fk');
+                });
+
+            Schema::connection(TOTEM_DATABASE_CONNECTION)
+                ->table(TOTEM_TABLE_PREFIX.'task_frequencies', function (Blueprint $table) {
+                    $table->dropForeign('task_frequencies_task_id_fk');
+                });
+        }
+
         Schema::connection(TOTEM_DATABASE_CONNECTION)
             ->table(TOTEM_TABLE_PREFIX.'task_results', function (Blueprint $table) {
                 $table->dropIndex('task_results_task_id_idx');
                 $table->dropIndex('task_results_ran_at_idx');
-            });
-
-        Schema::connection(TOTEM_DATABASE_CONNECTION)
-            ->table(TOTEM_TABLE_PREFIX.'task_frequencies', function (Blueprint $table) {
-                $table->dropForeign('task_frequencies_task_id_fk');
             });
 
         Schema::connection(TOTEM_DATABASE_CONNECTION)


### PR DESCRIPTION
SQLite will throw the following error when rolling back migrations without this change: "This database driver does not support dropping foreign keys by name". This fix just checks if the database driver is not "sqlite" before attempting to drop foreign key indexes by name.