### PR TITLE
Fix empty output popup (v12.0.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project follows [Semantic Versioning](CONTRIBUTING.md).
 
 ---
 
+## v12.0.2 - 04/21/2026
+
+### Fixed
+
+- Empty output popup on the task-view page. The `<task-output>` Vue component received an empty `:output` prop because `@json()` produced a JSON literal whose outer `"` delimiters collided with the HTML attribute's own `"` wrappers, making the rendered HTML malformed. Replaced with `Js::from()`, Laravel's purpose-built helper for embedding JS expressions inside HTML attributes. (PR #____)
+
 ## v11.0.0 - 03/27/2024
 
 - Add Laravel 11.x Support

--- a/resources/views/tasks/view.blade.php
+++ b/resources/views/tasks/view.blade.php
@@ -117,7 +117,7 @@
                         <td>{{$result->ran_at->toDateTimeString()}}</td>
                         <td>{{ number_format($result->duration / 1000 , 2)}} seconds</td>
                         <td>
-                            <task-output :output="@json($result->result)"></task-output>
+                            <task-output :output="{{ \Illuminate\Support\Js::from($result->result) }}"></task-output>
                         </td>
                     </tr>
                 @empty

--- a/tests/Feature/ViewTaskTest.php
+++ b/tests/Feature/ViewTaskTest.php
@@ -31,6 +31,7 @@ class ViewTaskTest extends TestCase
      *
      * Before v12.0.2, resources/views/tasks/view.blade.php used @json() to
      * bind the task result into the <task-output :output="..."> attribute.
+     *
      * @json() emits raw JSON whose outer `"` delimiters collide with the
      * attribute's own `"` wrappers, making the HTML malformed. Browsers
      * parse `:output=""hello""` as `:output=""` (empty) + orphan text, so

--- a/tests/Feature/ViewTaskTest.php
+++ b/tests/Feature/ViewTaskTest.php
@@ -2,6 +2,7 @@
 
 namespace Studio\Totem\Tests\Feature;
 
+use Studio\Totem\Result;
 use Studio\Totem\Task;
 use Studio\Totem\Tests\TestCase;
 
@@ -23,5 +24,130 @@ class ViewTaskTest extends TestCase
         $task = Task::factory()->create();
         $response = $this->get(route('totem.task.view', ['totemTask' => $task]));
         $response->assertStatus(403);
+    }
+
+    /**
+     * Regression test for v12.0.1's empty-output-popup bug.
+     *
+     * Before v12.0.2, resources/views/tasks/view.blade.php used @json() to
+     * bind the task result into the <task-output :output="..."> attribute.
+     * @json() emits raw JSON whose outer `"` delimiters collide with the
+     * attribute's own `"` wrappers, making the HTML malformed. Browsers
+     * parse `:output=""hello""` as `:output=""` (empty) + orphan text, so
+     * Vue receives an empty string and the modal's <pre> renders blank.
+     *
+     * Fix: use Js::from(), which for string input emits a bare single-quoted
+     * JS string literal (e.g. `'hello "world"'`). This is safe inside
+     * double-quoted HTML attributes because the inner `"` characters are
+     * unicode-escaped to `"` via JSON_HEX_QUOT.
+     *
+     * This test renders the task-view page with a result whose output
+     * contains every character class known to break attribute encoding,
+     * parses the response with DOMDocument, extracts the `:output`
+     * attribute value, decodes it, and asserts round-trip equality with
+     * the source string.
+     *
+     * Negative control: reverting the Blade change to `@json(...)` MUST
+     * cause this test to fail. Verify manually during PR review.
+     *
+     * Excluded from the corpus:
+     * - null bytes (`\0`) — the task_results.result column is a UTF-8
+     *   text column that does not accept them; they are unreachable in
+     *   production data.
+     */
+    public function test_output_attribute_roundtrips_edge_cases()
+    {
+        $corpus = implode("\n", [
+            'double "quotes" inside a line',
+            'backslash \\ and forward slash /',
+            'less-than <script>alert(1)</script> tags',
+            'apostrophe \'s and ampersand & symbols',
+            'emoji 🔥 and four-byte UTF-8 𝕏',
+            "CR\r LF newline above, tab\there, and nothing fancy",
+        ]);
+
+        $this->signIn();
+
+        $task = Task::factory()->create();
+        Result::factory()->create([
+            'task_id' => $task->id,
+            'result' => $corpus,
+            'duration' => 1234,
+            'ran_at' => now(),
+        ]);
+
+        $response = $this->get(route('totem.task.view', ['totemTask' => $task]));
+        $response->assertStatus(200);
+
+        $decoded = $this->extractTaskOutputAttribute($response->getContent());
+
+        $this->assertSame(
+            $corpus,
+            $decoded,
+            'Round-tripped :output attribute must exactly equal the source result string.'
+        );
+    }
+
+    /**
+     * Extract the first <task-output> element's :output attribute from the
+     * response HTML and decode it back to the original string.
+     *
+     * The attribute value is a JS expression. With the Js::from() fix, the
+     * attribute value is a bare single-quoted JS string literal (e.g.
+     * `'hello "world"'`) — Laravel's `Js.php:86-88` short path for scalar
+     * string inputs. The legacy `@json()` output was the raw JSON literal;
+     * HTML attribute parsing truncates that because its outer `"` delimiters
+     * collide with the attribute's own `"` wrappers.
+     */
+    private function extractTaskOutputAttribute(string $html): string
+    {
+        $dom = new \DOMDocument();
+        // libxml is strict about our custom elements; suppress warnings.
+        $previous = libxml_use_internal_errors(true);
+        $dom->loadHTML('<?xml encoding="UTF-8">'.$html);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+
+        $nodes = $dom->getElementsByTagName('task-output');
+        $this->assertGreaterThan(
+            0,
+            $nodes->length,
+            '<task-output> element must be present in the task-view response.'
+        );
+
+        /** @var \DOMElement $node */
+        $node = $nodes->item(0);
+        $attr = $node->getAttribute(':output');
+        $this->assertNotSame(
+            '',
+            $attr,
+            ':output attribute must not be empty — empty means the Blade binding broke again.'
+        );
+
+        // Two shapes we accept:
+        //   1. Js::from() form (the fix): a single-quoted JS string literal,
+        //      e.g. `'hello "world"'`. All special characters are
+        //      unicode-escaped (`"` for `"`, `'` for `'`, etc.) or
+        //      standard JSON-compatible escapes (`\\`, `\/`, `\r`, `\n`, `\t`),
+        //      so stripping the outer `'`s and wrapping in `"..."` yields
+        //      valid JSON we can json_decode.
+        //   2. Legacy @json() form (the bug): the raw JSON literal `"hello"`.
+        //      HTML attribute parsing truncates it; the assertNotSame above
+        //      catches that case, but we keep json_decode as a defensive path.
+        if (preg_match("/^'(.*)'$/s", $attr, $m)) {
+            $inner = $m[1];
+            $json = json_decode('"'.$inner.'"', true, 512, JSON_THROW_ON_ERROR);
+
+            return (string) $json;
+        }
+
+        // Defensive fallback for the legacy @json() shape. Unreachable in practice:
+        // if the fix is reverted, the assertNotSame('', $attr, …) guard above fires
+        // first because HTML parsing truncates the attribute to an empty string.
+        // Retained as documentation of what the broken shape would produce if some
+        // future change kept the attribute non-empty but still wrong.
+        $json = json_decode($attr, true);
+
+        return (string) $json;
     }
 }


### PR DESCRIPTION
## Summary

Repairs the empty task-output popup on the task-view page. The bug is a Blade attribute-binding regression introduced by the Vue 3 modernization in v12.0.0: `@json($result->result)` produces JSON whose outer `"` delimiters break HTML attribute parsing, so the Vue `:output` prop arrives empty and the modal's `<pre>` renders blank. Fix is a one-line swap to `Js::from()`.

## Root cause evidence

\`\`\`
$ php -r 'echo json_encode("hello", JSON_HEX_QUOT) . PHP_EOL;'
"hello"

$ php -r 'echo json_encode("say \"hi\"", JSON_HEX_QUOT) . PHP_EOL;'
"say \"hi\""
\`\`\`

`JSON_HEX_QUOT` escapes `"` characters *inside* JSON string content but not the structural delimiter quotes (escaping those would break JSON grammar). So `@json(\$result->result)` inside a double-quoted HTML attribute produces `:output=""hello""`, which the browser parses as `:output=""` (empty) followed by orphan text.

`Js::from()` emits (for string input) a bare single-quoted JS string literal like `'hello "world"'` — safe inside double-quoted HTML attributes because the inner `"` characters are unicode-escaped via `JSON_HEX_QUOT`.

## Changes

- `resources/views/tasks/view.blade.php:120` — replace `@json(\$result->result)` with `{{ \Illuminate\Support\Js::from(\$result->result) }}`.
- `tests/Feature/ViewTaskTest.php` — new `test_output_attribute_roundtrips_edge_cases` regression test. Creates a task + result with a corpus of characters that previously broke the attribute (`\"`, `\`, `/`, `<script>`, `'`, `&`, emoji, 4-byte UTF-8, CR/LF/tab), renders the view, parses the `:output` attribute with `DOMDocument`, decodes it, asserts round-trip equality with the source. Null bytes excluded with documented rationale (text column rejects them).
- `CHANGELOG.md` — new `## v12.0.2 - 04/21/2026` entry describing the fix.

## Test plan

- [x] New regression test fails against unfixed code (verified locally — pre-fix run: 1 failure at `:output attribute must not be empty`).
- [x] New regression test passes after the fix (1 test / 4 assertions).
- [x] Full existing PHPUnit suite stays green (79 tests / 519 assertions).
- [ ] CI matrix passes on all blocking combos (PHP 8.2/8.3/8.4 × Laravel 11.*/12.*).

## Design spec

See \`docs/plans/2026-04-21-totem-v13-release-design.md\` §1 for the root-cause analysis, acceptance criteria (AC1.1–AC1.4), and release context. This PR maps to Section 1 of that spec.

## Release plan

Tag \`v12.0.2\` after merge. No composer constraint changes. No other code changes ship with this release.

## Post-merge

The CHANGELOG entry currently has a \`(PR #____)\` placeholder — I'll fill in the actual PR number in a follow-up commit once this PR number is known and before the v12.0.2 tag.