### PR TITLE
Fix intermittent CacheStoreTest failures in sync-queue CI environments

### DIFF
--- a/tests/Feature/CacheStoreTest.php
+++ b/tests/Feature/CacheStoreTest.php
@@ -3,6 +3,7 @@
 namespace Studio\Totem\Tests\Feature;
 
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Queue;
 use Studio\Totem\Repositories\EloquentTaskRepository;
 use Studio\Totem\Tests\TestCase;
 
@@ -72,6 +73,7 @@ class CacheStoreTest extends TestCase
     public function test_updating_task_clears_route_binding_cache()
     {
         config(['totem.cache_store' => 'totem_store']);
+        Queue::fake();
 
         $task = \Studio\Totem\Task::factory()->create();
         Cache::store('totem_store')->forever('totem.task.'.$task->id, $task);
@@ -86,6 +88,7 @@ class CacheStoreTest extends TestCase
     public function test_activating_task_clears_route_binding_cache()
     {
         config(['totem.cache_store' => 'totem_store']);
+        Queue::fake();
 
         $task = \Studio\Totem\Task::factory()->create();
         Cache::store('totem_store')->forever('totem.task.'.$task->id, $task);
@@ -98,6 +101,7 @@ class CacheStoreTest extends TestCase
     public function test_deactivating_task_clears_route_binding_cache()
     {
         config(['totem.cache_store' => 'totem_store']);
+        Queue::fake();
 
         $task = \Studio\Totem\Task::factory()->create();
         Cache::store('totem_store')->forever('totem.task.'.$task->id, $task);


### PR DESCRIPTION
## Summary

Three tests in `tests/Feature/CacheStoreTest.php` have failed in GitHub Actions CI on `12.x` since 2026-02-25 while passing on most local dev environments. This PR stabilizes them with `Queue::fake()`. Test-harness-only change — no `src/` modifications, no runtime behavior impact.

**Affected tests:**
- `test_updating_task_clears_route_binding_cache`
- `test_activating_task_clears_route_binding_cache`
- `test_deactivating_task_clears_route_binding_cache`

Same CI failure signature on every run: `Failed asserting that true is false.`

## Root cause

The `Updated`, `Activated`, and `Deactivated` events each have three listeners wired in `src/Providers/TotemEventServiceProvider.php:19-21`:

1. `BustCacheImmediately` — plain class, runs sync.
2. `BustCache` — extends `Listener` which `implements ShouldQueue`.
3. `BuildCache` — same.

`BuildCache::handle()` calls `$this->tasks->find($event->task->id)`, which in `EloquentTaskRepository::find()` uses `rememberForever('totem.task.'.$id, ...)` — this **re-populates** the exact cache key the tests assert was cleared.

Whether the two queued listeners execute synchronously during `Event::dispatch()` depends on `config('queue.default')`:

- **Local environments** that ran `testbench` CLI previously have a stale `vendor/orchestra/testbench-core/laravel/.env` setting `QUEUE_CONNECTION=database`. The queued listeners get pushed to a DB queue and never execute during the test — only `BustCacheImmediately` fires, cache stays empty, assertion passes.
- **CI (fresh install)** has no `.env` file at that path (testbench ships only `.env.example`), so `env('QUEUE_CONNECTION', 'sync')` falls back to `sync`. `BuildCache` runs synchronously during dispatch and repopulates `totem.task.{id}` before the assertion. Test fails.

The test `test_bust_cache_clears_from_configured_store` passes in both environments because `Deleting::dispatch` only wires `BustCacheImmediately` — no `BuildCache` to repopulate.

## Fix

Add `Queue::fake()` to the three affected tests. The fake swaps Laravel's queue manager with a no-op recorder, so queued listeners get recorded and dropped instead of executed synchronously. `BustCacheImmediately` (not queued) still runs and clears the cache — matching the tests' evident intent of "only the immediate listener should matter here."

```diff
+use Illuminate\Support\Facades\Queue;
...
 public function test_updating_task_clears_route_binding_cache()
 {
     config(['totem.cache_store' => 'totem_store']);
+    Queue::fake();
     ...
 }
```

(Same two-line addition in each of the three tests.)

## Why this fix and not an alternative

- **Not `\$this->loadEnvironmentVariables = true` in `TestCase.php`:** masks this class of queue-timing dependency across the entire suite, bigger surface-area change.
- **Not removing the queued listeners from `TotemEventServiceProvider`:** changes runtime behavior (production would lose the background cache-warming).
- **Not setting `QUEUE_CONNECTION` in `getEnvironmentSetUp`:** same over-broad scope; the problem is specific to these three tests' assumption that "only sync listeners matter."

## Verification

Local reproduction of CI:

```bash
# With stale vendor .env (typical local): 
vendor/bin/phpunit tests/Feature/CacheStoreTest.php  # 8/8 pass (was already passing)

# Simulate CI (no .env):
mv vendor/orchestra/testbench-core/laravel/.env vendor/orchestra/testbench-core/laravel/.env.disabled
vendor/bin/phpunit tests/Feature/CacheStoreTest.php  # BEFORE FIX: 3 failures. AFTER FIX: 8/8 pass.
vendor/bin/phpunit                                    # Full suite: 78/78 pass (515 assertions).
mv vendor/orchestra/testbench-core/laravel/.env.disabled vendor/orchestra/testbench-core/laravel/.env
```

Both scenarios verified locally with this fix applied.

## Test plan

- [x] All 8 `CacheStoreTest` tests pass locally with the stale vendor `.env` present.
- [x] All 8 `CacheStoreTest` tests pass locally with the vendor `.env` removed (CI condition).
- [x] Full existing PHPUnit suite stays green locally (78 tests / 515 assertions).
- [ ] CI matrix all 6 combos green (PHP 8.2/8.3/8.4 × Laravel 11.*/12.*).

## Release plan

No tag. No CHANGELOG entry (this is a test-only fix — no user-facing behavior change). Companion to PR #415 (v12.0.2 popup hotfix) which was blocked by this pre-existing CI issue.

## Sequencing note

PR #415 (hotfix/empty-output-popup) will rebase onto this fix once merged, so its CI run exercises the fixed test harness.