### PR TITLE
v13 baseline — drop L10/11 + PHP 8.2, add Laravel 13, bump CI matrix

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -5,33 +5,74 @@ on: [push, pull_request]
 jobs:
   laravel-tests:
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental == true }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
-        php: [ 8.2, 8.3, 8.4 ]
-        laravel: [ 11.*, 12.* ]
-        stability: [ prefer-stable ]
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+        os: [ubuntu-latest]
+        php: ['8.3', '8.4']
+        laravel: ['12.*', '13.*']
+        dependencies: [prefer-lowest, prefer-stable]
+        experimental: [false]
+        include:
+          # PHP 8.5 non-blocking smoke — 4 combos, all experimental
+          - { os: ubuntu-latest, php: '8.5', laravel: '12.*', dependencies: prefer-lowest,  experimental: true }
+          - { os: ubuntu-latest, php: '8.5', laravel: '12.*', dependencies: prefer-stable,  experimental: true }
+          - { os: ubuntu-latest, php: '8.5', laravel: '13.*', dependencies: prefer-lowest,  experimental: true }
+          - { os: ubuntu-latest, php: '8.5', laravel: '13.*', dependencies: prefer-stable,  experimental: true }
+    name: "PHP ${{ matrix.php }} / L${{ matrix.laravel }} / ${{ matrix.dependencies }}${{ matrix.experimental && ' (experimental)' || '' }}"
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php }}
-        extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
-        coverage: none
-    - name: Cache dependencies
-      uses: actions/cache@v4
-      with:
-        path: ~/.composer/cache/files
-        key: ${{ runner.os }}-${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.php }}-composer-
-    - name: Install dependencies
-      run: |
-        composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
-        composer update --${{ matrix.stability }} --prefer-dist --no-interaction
-    - name: Execute tests (Unit and Feature tests) via PHPUnit
-      run: vendor/bin/phpunit
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+          coverage: none
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache/files
+          key: ${{ runner.os }}-php${{ matrix.php }}-L${{ matrix.laravel }}-${{ matrix.dependencies }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: |
+            ${{ runner.os }}-php${{ matrix.php }}-L${{ matrix.laravel }}-${{ matrix.dependencies }}-
+            ${{ runner.os }}-php${{ matrix.php }}-
+
+      - name: Pin Laravel version for this job
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+
+      - name: Install dependencies (${{ matrix.dependencies }})
+        run: |
+          composer update --${{ matrix.dependencies }} --prefer-dist --no-interaction
+
+      - name: Verify Laravel floor (prefer-lowest only)
+        if: matrix.dependencies == 'prefer-lowest' && matrix.experimental != true
+        run: |
+          set -euo pipefail
+          resolved=$(composer show laravel/framework --format=json | php -r 'echo json_decode(stream_get_contents(STDIN), true)["versions"][0];' | sed 's/^v//')
+          case "${{ matrix.laravel }}" in
+            12.*) min="12.0.0" ;;
+            13.*) min="13.0.0" ;;
+            *) echo "Unknown Laravel major: ${{ matrix.laravel }}"; exit 1 ;;
+          esac
+          R="$resolved" M="$min" php -r '
+            $r = getenv("R");
+            $m = getenv("M");
+            if ($r === "" || $m === "") {
+              fwrite(STDERR, "Version extraction failed (resolved=\"$r\", min=\"$m\")\n");
+              exit(2);
+            }
+            if (version_compare($r, $m, "<")) {
+              fwrite(STDERR, "laravel/framework resolved to $r, below declared floor $m for Laravel ${{ matrix.laravel }}\n");
+              exit(1);
+            }
+            echo "laravel/framework resolved to $r (floor $m) -- ok\n";
+          '
+
+      - name: Execute tests (PHPUnit)
+        # PR 2 uses PHPUnit; PR 3 replaces this with `vendor/bin/pest`.
+        run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://github.com/codestudiohq/laravel-totem/blob/8.0/resources/assets/img/totem.png?raw=true" alt="Laravel Totem"/>
 </p>
 <p align="center">
-<img src="https://github.com/always-open/laravel-totem/workflows/Laravel/badge.svg?branch=11.x" alt="Build Status">
+<img src="https://github.com/always-open/laravel-totem/workflows/Laravel/badge.svg?branch=13.x" alt="Build Status">
 <a href="https://packagist.org/packages/studio/laravel-totem"><img src="https://poser.pugx.org/studio/laravel-totem/license.svg" alt="License"></a>
 </p>
 
@@ -14,15 +14,23 @@ Manage your `Laravel Schedule` from a pretty dashboard. Schedule your `Laravel C
 
 #### Compatibility Matrix
 
-| <span align="left">Laravel</span> | <span align="left">Totem</span> |
-|:----------------------------------|--------------------------------:|
-| 12.x                              |                            11.x |
-| 11.x                              |                            11.x |
+| Laravel | Totem | Notes                                        |
+|:--------|------:|:---------------------------------------------|
+| 13.x    | 13.x  | Current                                      |
+| 12.x    | 13.x  | Current release line — Laravel 13 runtime support |
+| 12.x    | 12.x  | Maintained                                   |
+| 11.x    | 12.x  | Maintained                                   |
+| 11.x    | 11.x  | Maintained                                   |
+| 10.x    | 11.x  | Maintained                                   |
 
 #### Requirements
 
-- PHP 8.2+
-- Laravel 11.x or 12.x
+- PHP 8.3+
+- Laravel 12.x or 13.x
+
+Earlier Totem majors are maintained for legacy Laravel support:
+- Totem 12.x supports Laravel 11.x and 12.x (PHP 8.2+).
+- Totem 11.x supports Laravel 10.x, 11.x, and 12.x (PHP 8.2+).
 
 #### Installing
 

--- a/composer.json
+++ b/composer.json
@@ -20,20 +20,20 @@
     }
   ],
   "require": {
-    "php": "^8.2.0",
+    "php": "^8.3",
     "ext-json": "*",
-    "illuminate/bus": "^10.0|^11.0|^12.0",
-    "illuminate/console": "^10.0|^11.0|^12.0",
-    "illuminate/contracts": "^10.0|^11.0|^12.0",
-    "illuminate/database": "^10.0|^11.0|^12.0",
-    "illuminate/events": "^10.0|^11.0|^12.0",
-    "illuminate/notifications": "^10.0|^11.0|^12.0"
+    "illuminate/bus": "^12.0|^13.0",
+    "illuminate/console": "^12.0|^13.0",
+    "illuminate/contracts": "^12.0|^13.0",
+    "illuminate/database": "^12.0|^13.0",
+    "illuminate/events": "^12.0|^13.0",
+    "illuminate/notifications": "^12.0|^13.0"
   },
   "require-dev": {
     "laravel/slack-notification-channel": "^3.7",
     "laravel/vonage-notification-channel": "^3.3",
-    "orchestra/testbench": "^8.0|^9.0|^10.0",
-    "phpunit/phpunit": "^10.0|^11.0|^12.0"
+    "orchestra/testbench": "^10.0|^11.0",
+    "phpunit/phpunit": "^11.0|^12.0"
   },
   "suggest": {
     "laravel/slack-notification-channel": "Required for Slack notifications.",


### PR DESCRIPTION
## Summary

Mechanical version-bump PR for the v13.0 release line. No `src/` changes. No test-framework changes. Everything else follows:

- PHP floor: 8.3 (dropped 8.2).
- Laravel: 12.x and 13.x (dropped 10.x, 11.x).
- Testbench: `^10.0|^11.0` (dropped 8, 9).
- PHPUnit: `^11.0|^12.0` (dropped 10). Still present — PR 3 swaps to Pest.
- CI matrix: PHP {8.3, 8.4} × Laravel {12, 13} × dependencies {prefer-lowest, prefer-stable} = 8 blocking combos. PHP 8.5 × same = 4 non-blocking experimental combos.
- README: compat matrix expanded to reflect all supported Totem majors.

## Resolved versions (local, 2026-04-21, PHP 8.4 / prefer-stable)

- `laravel/framework`: v13.6.0 (Laravel 13 stable)
- `orchestra/testbench`: v11.1.0
- `phpunit/phpunit`: v12.5.23
- `illuminate/support`: v13.6.0 (via laravel/framework)

Symfony transitives bumped 7.4 → 8.0; `laravel/tinker` v2 → v3. No direct use in `src/`; all tests pass.

## Laravel 13 upgrade-guide citations

Per spec §2.1, these upgrade-guide sections were walked to verify no breaking changes to Totem's integration points:

- Service-provider auto-discovery (`extra.laravel.providers` unchanged): https://laravel.com/docs/13.x/upgrade#package-discovery
- `Illuminate\\Support\\Js` (used in v12.0.2 popup fix, forward-ported on 13.x): https://laravel.com/docs/13.x/upgrade#strings — cross-ref https://github.com/laravel/framework/blob/13.x/src/Illuminate/Support/Js.php
- `Schedule::command()` + `->thenWithOutput()` (used in \`src/Providers/TotemServiceProvider.php::scheduleTotemTasks\`): https://laravel.com/docs/13.x/upgrade#scheduling — cross-ref https://github.com/laravel/framework/blob/13.x/src/Illuminate/Console/Scheduling/Event.php
- Notification channel contracts (\`src/Notifications/TaskCompleted.php\`): https://laravel.com/docs/13.x/upgrade#notifications

If any of these anchors have re-anchored by review time, the PR body needs updating — flag it.

## CI matrix

**Blocking (8 combos):** PHP 8.3/8.4 × Laravel 12.*/13.* × prefer-lowest/prefer-stable.

**Non-blocking experimental (4 combos):** PHP 8.5 × Laravel 12.*/13.* × prefer-lowest/prefer-stable. \`continue-on-error: true\` is gated by \`matrix.experimental\` (default \`false\`, overridden to \`true\` in the include entries).

The \`prefer-lowest\` lanes include a floor-verification step that queries \`composer show laravel/framework --format=json\`, extracts the resolved version, and fails the lane if it's below the declared Laravel major floor (12.0.0 / 13.0.0). \`set -euo pipefail\` is enabled so empty pipelines fail loudly. Verified locally against both L12 prefer-lowest (resolved 12.1.1) and L13 prefer-lowest (resolved 13.0.0) — both pass the check.

## Test plan

- [x] \`composer validate --strict\` clean.
- [x] \`composer update --prefer-dist\` resolves cleanly against Laravel 13.x stable locally.
- [x] Full PHPUnit suite green locally on Laravel 13.6.0 / prefer-stable / PHP 8.4 (79 tests / 522 assertions).
- [x] Floor-verification step manually simulated for L12 and L13 prefer-lowest resolutions.
- [ ] CI blocking matrix (8 combos) green.
- [ ] CI experimental PHP 8.5 lanes run without blocking the merge.

## Composer.lock note

\`composer.lock\` is gitignored in this repo (commit \`e23f9fb\` titled "fix : remove composer.lock") per library-package convention. The lockfile is regenerated by each consumer. CI's \`composer update\` exercises the fresh resolution.

## Design spec

See \`docs/plans/2026-04-21-totem-v13-release-design.md\` §2 (Section 2: PR 2). ACs AC2.1–AC2.5.

## Release plan

No release triggered by this PR alone. v13.0.0 is tagged after PR 5 (release prep). This PR is the first of four v13 PRs on \`13.x\` that precede the tag. Prerequisite for PR 3 (Pest migration) and PR 4 (type sweep).